### PR TITLE
Update printf of 64-bit integers to use C99 format specifiers

### DIFF
--- a/src/betree.c
+++ b/src/betree.c
@@ -522,17 +522,17 @@ bool betree_insert_with_constants(struct betree* tree,
 {
     struct ast_node* node;
     if(parse(expr, &node) != 0) {
-        fprintf(stderr, "Can't parse %ld\n", id);
+        fprintf(stderr, "Can't parse %"PRIbst"\n", id);
         return false;
     }
     assign_variable_id(tree->config, node);
     if(!is_valid(tree->config, node)) {
-        fprintf(stderr, "Can't validate %ld\n", id);
+        fprintf(stderr, "Can't validate %"PRIbst"\n", id);
         free_ast_node(node);
         return false;
     }
     if(!assign_constants(constant_count, constants, node)) {
-        fprintf(stderr, "Can't assign constants %ld\n", id);
+        fprintf(stderr, "Can't assign constants %"PRIbst"\n", id);
         return false;
     }
     assign_str_id(tree->config, node, false);
@@ -548,7 +548,7 @@ const struct betree_sub* betree_make_sub(struct betree* tree, betree_sub_t id, s
 {
     struct ast_node* node;
     if(parse(expr, &node) != 0) {
-        fprintf(stderr, "Can't parse %ld\n", id);
+        fprintf(stderr, "Can't parse %"PRIbst"\n", id);
         return false;
     }
     assign_variable_id(tree->config, node);
@@ -561,7 +561,7 @@ const struct betree_sub* betree_make_sub(struct betree* tree, betree_sub_t id, s
         return false;
     }
     if(!assign_constants(constant_count, constants, node)) {
-        fprintf(stderr, "Can't assign constants %ld\n", id);
+        fprintf(stderr, "Can't assign constants %"PRIbst"\n", id);
         return false;
     }
     assign_str_id(tree->config, node, true);

--- a/src/betree.h
+++ b/src/betree.h
@@ -3,8 +3,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 typedef uint64_t betree_sub_t;
+#define PRIbst PRIu64
 
 struct config;
 struct cnode;

--- a/src/debug.c
+++ b/src/debug.c
@@ -210,7 +210,7 @@ static void write_dot_file_lnode_names(
                     fprintf(f, ", ");
                 }
             }
-            fprintf(f, "S<sub>%lu</sub>", lnode->subs[i]->id);
+            fprintf(f, "S<sub>%"PRIbst"</sub>", lnode->subs[i]->id);
         }
         fprintf(f, "\\}>, color=lightblue1, fillcolor=lightblue1, style=filled, shape=record]\n");
     }
@@ -241,7 +241,7 @@ static void write_dot_file_cdir_td(FILE* f,
     if(current_depth == 0) {
         print_spaces(f, level);
         if(cdir == NULL) {
-            fprintf(f, "<td colspan=\"%lu\"></td>\n", colspan);
+            fprintf(f, "<td colspan=\"%"PRIu64"\"></td>\n", colspan);
         }
         else {
             const char* name = get_name_cdir(config, cdir);
@@ -249,7 +249,7 @@ static void write_dot_file_cdir_td(FILE* f,
                 case(BETREE_INTEGER):
                 case(BETREE_INTEGER_LIST):
                     fprintf(f,
-                        "<td colspan=\"%lu\" port=\"%s\">[%ld, %ld]</td>\n",
+                        "<td colspan=\"%"PRIu64"\" port=\"%s\">[%"PRIi64", %"PRIi64"]</td>\n",
                         colspan,
                         name,
                         cdir->bound.imin,
@@ -257,7 +257,7 @@ static void write_dot_file_cdir_td(FILE* f,
                     break;
                 case(BETREE_FLOAT): {
                     fprintf(f,
-                        "<td colspan=\"%lu\" port=\"%s\">[%.0f, %.0f]</td>\n",
+                        "<td colspan=\"%"PRIu64"\" port=\"%s\">[%.0f, %.0f]</td>\n",
                         colspan,
                         name,
                         cdir->bound.fmin,
@@ -268,7 +268,7 @@ static void write_dot_file_cdir_td(FILE* f,
                     const char* min = cdir->bound.bmin ? "true" : "false";
                     const char* max = cdir->bound.bmax ? "true" : "false";
                     fprintf(f,
-                        "<td colspan=\"%lu\" port=\"%s\">[%s, %s]</td>\n",
+                        "<td colspan=\"%"PRIu64"\" port=\"%s\">[%s, %s]</td>\n",
                         colspan,
                         name,
                         min,
@@ -280,7 +280,7 @@ static void write_dot_file_cdir_td(FILE* f,
                 case(BETREE_INTEGER_ENUM):
                 case(BETREE_INTEGER_LIST_ENUM):
                     fprintf(f,
-                        "<td colspan=\"%lu\" port=\"%s\">[%zu, %zu]</td>\n",
+                        "<td colspan=\"%"PRIu64"\" port=\"%s\">[%zu, %zu]</td>\n",
                         colspan,
                         name,
                         cdir->bound.smin,

--- a/src/printer.c
+++ b/src/printer.c
@@ -393,7 +393,7 @@ void print_variable(const struct betree_variable* v)
             printf("%s", v->value.boolean_value ? "true" : "false");
             break;
         case BETREE_INTEGER:
-            printf("%ld", v->value.integer_value);
+            printf("%"PRIi64, v->value.integer_value);
             break;
         case BETREE_FLOAT:
             printf("%.2f", v->value.float_value);
@@ -410,7 +410,7 @@ void print_variable(const struct betree_variable* v)
             printf("%s", inner);
             break;
         case BETREE_INTEGER_ENUM:
-            printf("%ld", v->value.integer_enum_value.integer);
+            printf("%"PRIi64, v->value.integer_enum_value.integer);
             break;
         case BETREE_INTEGER_LIST_ENUM:
             inner = integer_enum_list_value_to_string(v->value.integer_enum_list_value);
@@ -450,13 +450,13 @@ void print_attr_domain(const struct attr_domain* domain)
                 printf("INT64_MIN, ");
             }
             else {
-                printf("%ld, ", domain->bound.imin);
+                printf("%"PRIi64", ", domain->bound.imin);
             }
             if(domain->bound.imax == INT64_MAX) {
                 printf("INT64_MAX]\n");
             }
             else {
-                printf("%ld]\n", domain->bound.imax);
+                printf("%"PRIi64"]\n", domain->bound.imax);
             }
             break;
         case BETREE_FLOAT:
@@ -492,13 +492,13 @@ void print_attr_domain(const struct attr_domain* domain)
                 printf("INT64_MIN, ");
             }
             else {
-                printf("%ld, ", domain->bound.imin);
+                printf("%"PRIi64", ", domain->bound.imin);
             }
             if(domain->bound.imax == INT64_MAX) {
                 printf("INT64_MAX]\n");
             }
             else {
-                printf("%ld]\n", domain->bound.imax);
+                printf("%"PRIi64"]\n", domain->bound.imax);
             }
             break;
         case BETREE_STRING_LIST:
@@ -558,13 +558,13 @@ void print_cdir(const struct cdir* cdir)
                 printf("INT64_MIN, ");
             }
             else {
-                printf("%ld, ", cdir->bound.imin);
+                printf("%"PRIi64", ", cdir->bound.imin);
             }
             if(cdir->bound.imax == INT64_MAX) {
                 printf("INT64_MAX]\n");
             }
             else {
-                printf("%ld]\n", cdir->bound.imax);
+                printf("%"PRIi64"]\n", cdir->bound.imax);
             }
             break;
         case BETREE_FLOAT:
@@ -597,13 +597,13 @@ void print_cdir(const struct cdir* cdir)
                 printf("INT64_MIN, ");
             }
             else {
-                printf("%ld, ", cdir->bound.imin);
+                printf("%"PRIi64", ", cdir->bound.imin);
             }
             if(cdir->bound.imax == INT64_MAX) {
                 printf("INT64_MAX]\n");
             }
             else {
-                printf("%ld]\n", cdir->bound.imax);
+                printf("%"PRIi64"]\n", cdir->bound.imax);
             }
             break;
         case BETREE_STRING_LIST:

--- a/src/tree.c
+++ b/src/tree.c
@@ -1682,7 +1682,7 @@ void event_to_string(const struct betree_event* event, char* buffer)
                 break;
             }
             case(BETREE_INTEGER_ENUM): {
-                length += sprintf(buffer + length, "%s = %ld", attr, pred->value.integer_enum_value.integer);
+                length += sprintf(buffer + length, "%s = %"PRIi64, attr, pred->value.integer_enum_value.integer);
                 break;
             }
             case(BETREE_INTEGER_LIST_ENUM): {


### PR DESCRIPTION
I noticed a number of warnings when compiling this and figured I'd put together a quick fix. While betree_sub_t is a typedef of uint64_t, I added a PRIbst variant so that, if anyone ever changes it, they can update that accordingly. Do with it what you will. Thanks for writing this awesome library!