### PR TITLE
Feature/validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,7 @@ valgrind: $(TEST_BINARIES)
 	$(VALGRIND) build/tests/printer_tests
 	$(VALGRIND) build/tests/report_tests
 	$(VALGRIND) build/tests/special_tests
+	$(VALGRIND) build/tests/valid_tests
 	#$(VALGRIND) build/tests/real_tests 1
 
 callgrind:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The following types are supported:
 The expressions supported are as follow:
 
 * Comparison: `<`, `<=`, `>` and `>=`. They work on integers and floats.
-* Equality: `=` and `<>`. They work on integers, floats and strings.
+* Equality: `=` and `<>`. They work on integers, integer enums, floats and strings.
 * Boolean: `and`, `or`, `not` and checking a boolean variable.
 * Set: `in` and `not in`. Two possibilities:
     * value `in` variable. Here value is an integer or a string.

--- a/src/ast.h
+++ b/src/ast.h
@@ -125,7 +125,6 @@ enum set_right_value_e {
     AST_SET_RIGHT_VALUE_INTEGER_LIST,
     AST_SET_RIGHT_VALUE_STRING_LIST,
     AST_SET_RIGHT_VALUE_VARIABLE,
-    AST_SET_RIGHT_VALUE_INTEGER_LIST_ENUM,
 };
 
 struct set_right_value {
@@ -134,7 +133,6 @@ struct set_right_value {
         struct betree_integer_list* integer_list_value;
         struct betree_string_list* string_list_value;
         struct attr_var variable_value;
-        struct betree_integer_enum_list* integer_enum_list_value;
     };
 };
 
@@ -343,3 +341,4 @@ bool fast_eq_expr(const struct ast_node* a, const struct ast_node* b);
 
 bool all_variables_in_config(const struct config* config, const struct ast_node* node);
 bool all_bounded_strings_valid(const struct config* config, const struct ast_node* node);
+bool all_exprs_valid(const struct config* config, const struct ast_node* node);

--- a/src/ast_compare.c
+++ b/src/ast_compare.c
@@ -41,25 +41,6 @@ static int cmp_string_list(struct betree_string_list* l1, struct betree_string_l
     return 0;
 }
 
-static int cmp_integer_enum_list(struct betree_integer_enum_list* l1, struct betree_integer_enum_list* l2)
-{
-    if(l1->count > l2->count) {
-        return 1;
-    }
-    if(l1->count < l2->count) {
-        return -1;
-    }
-    for(size_t i = 0; i < l1->count; i++) {
-        if(l1->integers[i].ienum > l2->integers[i].ienum) {
-            return 1;
-        }
-        if(l1->integers[i].ienum < l2->integers[i].ienum) {
-            return -1;
-        }
-    }
-    return 0;
-}
-
 static int compare_expr_cmp(struct ast_compare_expr* c1, struct ast_compare_expr* c2)
 {
     if(c1->op > c2->op) {
@@ -273,8 +254,6 @@ static int set_expr_cmp(struct ast_set_expr* s1, struct ast_set_expr* s2)
                 return -1;
             }
             return 0;
-        case AST_SET_RIGHT_VALUE_INTEGER_LIST_ENUM:
-            return cmp_integer_enum_list(s1->right_value.integer_enum_list_value, s2->right_value.integer_enum_list_value);
         default: abort();
     }
 }

--- a/src/betree.c
+++ b/src/betree.c
@@ -515,14 +515,17 @@ const struct betree_sub* betree_make_sub(struct betree* tree, betree_sub_t id, s
     fix_float_with_no_fractions(tree->config, node);
     if(!all_exprs_valid(tree->config, node)) {
         fprintf(stderr, "Invalid expression found\n");
+        free_ast_node(node);
         return NULL;
     }
     if(!all_variables_in_config(tree->config, node)) {
         fprintf(stderr, "Missing variable in config\n");
+        free_ast_node(node);
         return NULL;
     }
     if(!assign_constants(constant_count, constants, node)) {
         fprintf(stderr, "Can't assign constants %ld\n", id);
+        free_ast_node(node);
         return NULL;
     }
     sort_lists(node);

--- a/src/betree.c
+++ b/src/betree.c
@@ -510,16 +510,16 @@ const struct betree_sub* betree_make_sub(struct betree* tree, betree_sub_t id, s
         return NULL;
     }
     assign_variable_id(tree->config, node);
+    if(!all_variables_in_config(tree->config, node)) {
+        fprintf(stderr, "Missing variable in config\n");
+        free_ast_node(node);
+        return NULL;
+    }
     assign_str_id(tree->config, node, true);
     assign_ienum_id(tree->config, node, true);
     fix_float_with_no_fractions(tree->config, node);
     if(!all_exprs_valid(tree->config, node)) {
         fprintf(stderr, "Invalid expression found\n");
-        free_ast_node(node);
-        return NULL;
-    }
-    if(!all_variables_in_config(tree->config, node)) {
-        fprintf(stderr, "Missing variable in config\n");
         free_ast_node(node);
         return NULL;
     }

--- a/src/betree.h
+++ b/src/betree.h
@@ -45,7 +45,6 @@ enum betree_value_type_e {
     BETREE_SEGMENTS,
     BETREE_FREQUENCY_CAPS,
     BETREE_INTEGER_ENUM,
-    BETREE_INTEGER_LIST_ENUM,
 };
 
 struct betree_integer_list;

--- a/src/clone.c
+++ b/src/clone.c
@@ -150,15 +150,6 @@ static struct betree_string_list* clone_string_list(struct betree_string_list* l
     return clone;
 }
 
-static struct betree_integer_enum_list* clone_integer_enum_list(struct betree_integer_enum_list* list)
-{
-    struct betree_integer_enum_list* clone = make_integer_enum_list(list->count);
-    for(size_t i = 0; i < list->count; i++) {
-        clone->integers[i] = list->integers[i];
-    }
-    return clone;
-}
-
 static struct set_right_value clone_set_right_value(struct set_right_value orig)
 {
     struct set_right_value clone = { .value_type = orig.value_type };
@@ -171,9 +162,6 @@ static struct set_right_value clone_set_right_value(struct set_right_value orig)
             break;
         case AST_SET_RIGHT_VALUE_VARIABLE:
             clone.variable_value = clone_attr_var(orig.variable_value);
-            break;
-        case AST_SET_RIGHT_VALUE_INTEGER_LIST_ENUM:
-            clone.integer_enum_list_value = clone_integer_enum_list(orig.integer_enum_list_value);
             break;
         default: abort();
     }

--- a/src/debug.c
+++ b/src/debug.c
@@ -99,7 +99,6 @@ static const char* get_path_cdir(const struct config* config, const struct cdir*
         case(BETREE_STRING):
         case(BETREE_STRING_LIST):
         case(BETREE_INTEGER_ENUM):
-        case(BETREE_INTEGER_LIST_ENUM):
             if(basprintf(&name, "%s_%zu_%zu", parent_path, cdir->bound.smin, cdir->bound.smax) < 0) {
                 abort();
             }
@@ -278,7 +277,6 @@ static void write_dot_file_cdir_td(FILE* f,
                 case(BETREE_STRING):
                 case(BETREE_STRING_LIST):
                 case(BETREE_INTEGER_ENUM):
-                case(BETREE_INTEGER_LIST_ENUM):
                     fprintf(f,
                         "<td colspan=\"%lu\" port=\"%s\">[%zu, %zu]</td>\n",
                         colspan,

--- a/src/event_parser.c
+++ b/src/event_parser.c
@@ -1,8 +1,9 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.5.1.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2020 Free Software Foundation,
+   Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -40,11 +41,14 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
+/* Undocumented macros, especially those whose name start with YY_,
+   are private implementation details.  Do not rely on them.  */
+
 /* Identify Bison output.  */
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "3.0.4"
+#define YYBISON_VERSION "3.5.1"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -67,9 +71,8 @@
 #define yydebug         zzdebug
 #define yynerrs         zznerrs
 
-
-/* Copy the first part of user declarations.  */
-#line 1 "src/event_parser.y" /* yacc.c:339  */
+/* First part of user prologue.  */
+#line 1 "src/event_parser.y"
 
     #include <stdint.h>
     #include <stdbool.h>
@@ -89,17 +92,30 @@
     #pragma GCC diagnostic ignored "-Wswitch-default"
     #pragma GCC diagnostic ignored "-Wshadow"
 #endif
-#line 28 "src/event_parser.y" /* yacc.c:339  */
+#line 28 "src/event_parser.y"
 
     int event_parse(const char *text, struct betree_event **event);
 
-#line 97 "src/event_parser.c" /* yacc.c:339  */
+#line 100 "src/event_parser.c"
 
-# ifndef YY_NULLPTR
-#  if defined __cplusplus && 201103L <= __cplusplus
-#   define YY_NULLPTR nullptr
+# ifndef YY_CAST
+#  ifdef __cplusplus
+#   define YY_CAST(Type, Val) static_cast<Type> (Val)
+#   define YY_REINTERPRET_CAST(Type, Val) reinterpret_cast<Type> (Val)
 #  else
-#   define YY_NULLPTR 0
+#   define YY_CAST(Type, Val) ((Type) (Val))
+#   define YY_REINTERPRET_CAST(Type, Val) ((Type) (Val))
+#  endif
+# endif
+# ifndef YY_NULLPTR
+#  if defined __cplusplus
+#   if 201103L <= __cplusplus
+#    define YY_NULLPTR nullptr
+#   else
+#    define YY_NULLPTR 0
+#   endif
+#  else
+#   define YY_NULLPTR ((void*)0)
 #  endif
 # endif
 
@@ -111,8 +127,8 @@
 # define YYERROR_VERBOSE 0
 #endif
 
-/* In a future release of Bison, this section will be replaced
-   by #include "event_parser.h".  */
+/* Use api.header.include to #include this header
+   instead of duplicating it here.  */
 #ifndef YY_ZZ_SRC_EVENT_PARSER_H_INCLUDED
 # define YY_ZZ_SRC_EVENT_PARSER_H_INCLUDED
 /* Debug traces.  */
@@ -151,27 +167,12 @@ extern int zzdebug;
     EVENT_STRING = 270
   };
 #endif
-/* Tokens.  */
-#define EVENT_LCURLY 258
-#define EVENT_RCURLY 259
-#define EVENT_LSQUARE 260
-#define EVENT_RSQUARE 261
-#define EVENT_COMMA 262
-#define EVENT_COLON 263
-#define EVENT_MINUS 264
-#define EVENT_NULL 265
-#define EVENT_TRUE 266
-#define EVENT_FALSE 267
-#define EVENT_INTEGER 268
-#define EVENT_FLOAT 269
-#define EVENT_STRING 270
 
 /* Value type.  */
 #if ! defined ZZSTYPE && ! defined ZZSTYPE_IS_DECLARED
-
 union ZZSTYPE
 {
-#line 32 "src/event_parser.y" /* yacc.c:355  */
+#line 32 "src/event_parser.y"
 
     int token;
     char *string;
@@ -192,9 +193,9 @@ union ZZSTYPE
 
     struct betree_event* event;
 
-#line 196 "src/event_parser.c" /* yacc.c:355  */
-};
+#line 197 "src/event_parser.c"
 
+};
 typedef union ZZSTYPE ZZSTYPE;
 # define ZZSTYPE_IS_TRIVIAL 1
 # define ZZSTYPE_IS_DECLARED 1
@@ -206,36 +207,81 @@ int zzparse (void *scanner);
 
 #endif /* !YY_ZZ_SRC_EVENT_PARSER_H_INCLUDED  */
 
-/* Copy the second part of user declarations.  */
 
-#line 212 "src/event_parser.c" /* yacc.c:358  */
 
 #ifdef short
 # undef short
 #endif
 
-#ifdef YYTYPE_UINT8
-typedef YYTYPE_UINT8 yytype_uint8;
-#else
-typedef unsigned char yytype_uint8;
+/* On compilers that do not define __PTRDIFF_MAX__ etc., make sure
+   <limits.h> and (if available) <stdint.h> are included
+   so that the code can choose integer types of a good width.  */
+
+#ifndef __PTRDIFF_MAX__
+# include <limits.h> /* INFRINGES ON USER NAME SPACE */
+# if defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#  include <stdint.h> /* INFRINGES ON USER NAME SPACE */
+#  define YY_STDINT_H
+# endif
 #endif
 
-#ifdef YYTYPE_INT8
-typedef YYTYPE_INT8 yytype_int8;
+/* Narrow types that promote to a signed type and that can represent a
+   signed or unsigned integer of at least N bits.  In tables they can
+   save space and decrease cache pressure.  Promoting to a signed type
+   helps avoid bugs in integer arithmetic.  */
+
+#ifdef __INT_LEAST8_MAX__
+typedef __INT_LEAST8_TYPE__ yytype_int8;
+#elif defined YY_STDINT_H
+typedef int_least8_t yytype_int8;
 #else
 typedef signed char yytype_int8;
 #endif
 
-#ifdef YYTYPE_UINT16
-typedef YYTYPE_UINT16 yytype_uint16;
+#ifdef __INT_LEAST16_MAX__
+typedef __INT_LEAST16_TYPE__ yytype_int16;
+#elif defined YY_STDINT_H
+typedef int_least16_t yytype_int16;
 #else
-typedef unsigned short int yytype_uint16;
+typedef short yytype_int16;
 #endif
 
-#ifdef YYTYPE_INT16
-typedef YYTYPE_INT16 yytype_int16;
+#if defined __UINT_LEAST8_MAX__ && __UINT_LEAST8_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST8_TYPE__ yytype_uint8;
+#elif (!defined __UINT_LEAST8_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST8_MAX <= INT_MAX)
+typedef uint_least8_t yytype_uint8;
+#elif !defined __UINT_LEAST8_MAX__ && UCHAR_MAX <= INT_MAX
+typedef unsigned char yytype_uint8;
 #else
-typedef short int yytype_int16;
+typedef short yytype_uint8;
+#endif
+
+#if defined __UINT_LEAST16_MAX__ && __UINT_LEAST16_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST16_TYPE__ yytype_uint16;
+#elif (!defined __UINT_LEAST16_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST16_MAX <= INT_MAX)
+typedef uint_least16_t yytype_uint16;
+#elif !defined __UINT_LEAST16_MAX__ && USHRT_MAX <= INT_MAX
+typedef unsigned short yytype_uint16;
+#else
+typedef int yytype_uint16;
+#endif
+
+#ifndef YYPTRDIFF_T
+# if defined __PTRDIFF_TYPE__ && defined __PTRDIFF_MAX__
+#  define YYPTRDIFF_T __PTRDIFF_TYPE__
+#  define YYPTRDIFF_MAXIMUM __PTRDIFF_MAX__
+# elif defined PTRDIFF_MAX
+#  ifndef ptrdiff_t
+#   include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  endif
+#  define YYPTRDIFF_T ptrdiff_t
+#  define YYPTRDIFF_MAXIMUM PTRDIFF_MAX
+# else
+#  define YYPTRDIFF_T long
+#  define YYPTRDIFF_MAXIMUM LONG_MAX
+# endif
 #endif
 
 #ifndef YYSIZE_T
@@ -243,15 +289,27 @@ typedef short int yytype_int16;
 #  define YYSIZE_T __SIZE_TYPE__
 # elif defined size_t
 #  define YYSIZE_T size_t
-# elif ! defined YYSIZE_T
+# elif defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
-#  define YYSIZE_T unsigned int
+#  define YYSIZE_T unsigned
 # endif
 #endif
 
-#define YYSIZE_MAXIMUM ((YYSIZE_T) -1)
+#define YYSIZE_MAXIMUM                                  \
+  YY_CAST (YYPTRDIFF_T,                                 \
+           (YYPTRDIFF_MAXIMUM < YY_CAST (YYSIZE_T, -1)  \
+            ? YYPTRDIFF_MAXIMUM                         \
+            : YY_CAST (YYSIZE_T, -1)))
+
+#define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
+
+/* Stored state numbers (used for stacks). */
+typedef yytype_int8 yy_state_t;
+
+/* State numbers in computations.  */
+typedef int yy_state_fast_t;
 
 #ifndef YY_
 # if defined YYENABLE_NLS && YYENABLE_NLS
@@ -265,30 +323,19 @@ typedef short int yytype_int16;
 # endif
 #endif
 
-#ifndef YY_ATTRIBUTE
-# if (defined __GNUC__                                               \
-      && (2 < __GNUC__ || (__GNUC__ == 2 && 96 <= __GNUC_MINOR__)))  \
-     || defined __SUNPRO_C && 0x5110 <= __SUNPRO_C
-#  define YY_ATTRIBUTE(Spec) __attribute__(Spec)
+#ifndef YY_ATTRIBUTE_PURE
+# if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_PURE __attribute__ ((__pure__))
 # else
-#  define YY_ATTRIBUTE(Spec) /* empty */
+#  define YY_ATTRIBUTE_PURE
 # endif
 #endif
 
-#ifndef YY_ATTRIBUTE_PURE
-# define YY_ATTRIBUTE_PURE   YY_ATTRIBUTE ((__pure__))
-#endif
-
 #ifndef YY_ATTRIBUTE_UNUSED
-# define YY_ATTRIBUTE_UNUSED YY_ATTRIBUTE ((__unused__))
-#endif
-
-#if !defined _Noreturn \
-     && (!defined __STDC_VERSION__ || __STDC_VERSION__ < 201112)
-# if defined _MSC_VER && 1200 <= _MSC_VER
-#  define _Noreturn __declspec (noreturn)
+# if defined __GNUC__ && 2 < __GNUC__ + (7 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_UNUSED __attribute__ ((__unused__))
 # else
-#  define _Noreturn YY_ATTRIBUTE ((__noreturn__))
+#  define YY_ATTRIBUTE_UNUSED
 # endif
 #endif
 
@@ -299,13 +346,13 @@ typedef short int yytype_int16;
 # define YYUSE(E) /* empty */
 #endif
 
-#if defined __GNUC__ && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
+#if defined __GNUC__ && ! defined __ICC && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
 /* Suppress an incorrect diagnostic about yylval being uninitialized.  */
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN \
-    _Pragma ("GCC diagnostic push") \
-    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")\
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                            \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
     _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
-# define YY_IGNORE_MAYBE_UNINITIALIZED_END \
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
     _Pragma ("GCC diagnostic pop")
 #else
 # define YY_INITIAL_VALUE(Value) Value
@@ -318,6 +365,20 @@ typedef short int yytype_int16;
 # define YY_INITIAL_VALUE(Value) /* Nothing. */
 #endif
 
+#if defined __cplusplus && defined __GNUC__ && ! defined __ICC && 6 <= __GNUC__
+# define YY_IGNORE_USELESS_CAST_BEGIN                          \
+    _Pragma ("GCC diagnostic push")                            \
+    _Pragma ("GCC diagnostic ignored \"-Wuseless-cast\"")
+# define YY_IGNORE_USELESS_CAST_END            \
+    _Pragma ("GCC diagnostic pop")
+#endif
+#ifndef YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_END
+#endif
+
+
+#define YY_ASSERT(E) ((void) (0 && (E)))
 
 #if ! defined yyoverflow || YYERROR_VERBOSE
 
@@ -394,17 +455,17 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
 {
-  yytype_int16 yyss_alloc;
+  yy_state_t yyss_alloc;
   YYSTYPE yyvs_alloc;
 };
 
 /* The size of the maximum gap between one aligned stack and the next.  */
-# define YYSTACK_GAP_MAXIMUM (sizeof (union yyalloc) - 1)
+# define YYSTACK_GAP_MAXIMUM (YYSIZEOF (union yyalloc) - 1)
 
 /* The size of an array large to enough to hold all stacks, each with
    N elements.  */
 # define YYSTACK_BYTES(N) \
-     ((N) * (sizeof (yytype_int16) + sizeof (YYSTYPE)) \
+     ((N) * (YYSIZEOF (yy_state_t) + YYSIZEOF (YYSTYPE)) \
       + YYSTACK_GAP_MAXIMUM)
 
 # define YYCOPY_NEEDED 1
@@ -417,11 +478,11 @@ union yyalloc
 # define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
     do                                                                  \
       {                                                                 \
-        YYSIZE_T yynewbytes;                                            \
+        YYPTRDIFF_T yynewbytes;                                         \
         YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
         Stack = &yyptr->Stack_alloc;                                    \
-        yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
-        yyptr += yynewbytes / sizeof (*yyptr);                          \
+        yynewbytes = yystacksize * YYSIZEOF (*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / YYSIZEOF (*yyptr);                        \
       }                                                                 \
     while (0)
 
@@ -433,12 +494,12 @@ union yyalloc
 # ifndef YYCOPY
 #  if defined __GNUC__ && 1 < __GNUC__
 #   define YYCOPY(Dst, Src, Count) \
-      __builtin_memcpy (Dst, Src, (Count) * sizeof (*(Src)))
+      __builtin_memcpy (Dst, Src, YY_CAST (YYSIZE_T, (Count)) * sizeof (*(Src)))
 #  else
 #   define YYCOPY(Dst, Src, Count)              \
       do                                        \
         {                                       \
-          YYSIZE_T yyi;                         \
+          YYPTRDIFF_T yyi;                      \
           for (yyi = 0; yyi < (Count); yyi++)   \
             (Dst)[yyi] = (Src)[yyi];            \
         }                                       \
@@ -448,30 +509,31 @@ union yyalloc
 #endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
-#define YYFINAL  6
+#define YYFINAL  7
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   71
+#define YYLAST   73
 
 /* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS  16
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  20
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  38
+#define YYNRULES  39
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  82
+#define YYNSTATES  83
 
-/* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
-   by yylex, with out-of-bounds checking.  */
 #define YYUNDEFTOK  2
 #define YYMAXUTOK   270
 
+
+/* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex, with out-of-bounds checking.  */
 #define YYTRANSLATE(YYX)                                                \
-  ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
-   as returned by yylex, without out-of-bounds checking.  */
-static const yytype_uint8 yytranslate[] =
+   as returned by yylex.  */
+static const yytype_int8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -507,10 +569,10 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[] =
 {
-       0,    94,    94,    96,    97,   100,   101,   104,   105,   106,
-     107,   108,   109,   110,   111,   112,   114,   115,   118,   119,
-     122,   123,   126,   128,   130,   133,   134,   137,   140,   141,
-     144,   147,   148,   152,   155,   158,   159,   163,   165
+       0,    94,    94,    95,    98,    99,   102,   103,   106,   107,
+     108,   109,   110,   111,   112,   113,   114,   116,   117,   120,
+     121,   124,   125,   128,   130,   132,   135,   136,   139,   142,
+     143,   146,   149,   150,   154,   157,   160,   161,   165,   167
 };
 #endif
 
@@ -534,126 +596,126 @@ static const char *const yytname[] =
 # ifdef YYPRINT
 /* YYTOKNUM[NUM] -- (External) token number corresponding to the
    (internal) symbol number NUM (which must be that of a token).  */
-static const yytype_uint16 yytoknum[] =
+static const yytype_int16 yytoknum[] =
 {
        0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
      265,   266,   267,   268,   269,   270
 };
 # endif
 
-#define YYPACT_NINF -9
+#define YYPACT_NINF (-10)
 
-#define yypact_value_is_default(Yystate) \
-  (!!((Yystate) == (-9)))
+#define yypact_value_is_default(Yyn) \
+  ((Yyn) == YYPACT_NINF)
 
-#define YYTABLE_NINF -1
+#define YYTABLE_NINF (-1)
 
-#define yytable_value_is_error(Yytable_value) \
+#define yytable_value_is_error(Yyn) \
   0
 
   /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
      STATE-NUM.  */
 static const yytype_int8 yypact[] =
 {
-      23,     3,    38,    33,    20,    -9,    -9,    -4,    -9,     3,
-       7,    15,    -9,    -9,    -9,    -9,    -9,    -9,    -9,    -9,
-      -9,    -9,    -9,    -9,    -9,    -9,    -9,    -9,    -9,    10,
-      -9,    29,    -9,    -9,    24,    26,    28,    -9,    30,    -9,
-      -9,    -9,    31,    36,    37,    -9,     8,    -9,    34,    -9,
-      40,    -9,    45,    44,     8,     8,    -9,    -9,     8,    -9,
-      -1,    -9,     8,    46,    48,    49,    34,    -9,    34,    50,
-      53,     8,    54,    55,     8,     8,    56,    59,     8,    -9,
-      60,    -9
+       8,    -3,    29,   -10,    36,     3,   -10,   -10,     4,   -10,
+      23,    15,    12,   -10,   -10,   -10,   -10,   -10,   -10,   -10,
+     -10,   -10,   -10,   -10,   -10,   -10,   -10,   -10,   -10,   -10,
+      18,   -10,    32,   -10,   -10,    -1,    28,    30,   -10,    35,
+     -10,   -10,   -10,    31,    42,    43,   -10,    -5,   -10,    37,
+     -10,    38,   -10,    46,    47,    -5,    -5,   -10,   -10,    -5,
+     -10,    17,   -10,    -5,    49,    51,    52,    37,   -10,    37,
+      54,    56,    -5,    58,    59,    -5,    -5,    62,    57,    -5,
+     -10,    64,   -10
 };
 
   /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
      Performed when YYTABLE does not specify something else to do.  Zero
      means the default is an error.  */
-static const yytype_uint8 yydefact[] =
+static const yytype_int8 yydefact[] =
 {
-       0,     0,     0,     0,     0,     3,     1,     0,     2,     0,
-       0,     0,     6,    16,    17,    18,    20,    22,     5,     7,
-       8,     9,    10,    11,    12,    13,    14,    15,     4,     0,
-      23,     0,    25,    28,     0,     0,     0,    31,     0,    35,
-      19,    21,     0,     0,     0,    24,     0,    27,     0,    30,
-       0,    34,     0,     0,     0,     0,    26,    29,     0,    32,
-       0,    36,     0,     0,     0,     0,     0,    33,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,    37,
-       0,    38
+       0,     0,     0,     2,     0,     0,     4,     1,     0,     3,
+       0,     0,     0,     7,    17,    18,    19,    21,    23,     6,
+       8,     9,    10,    11,    12,    13,    14,    15,    16,     5,
+       0,    24,     0,    26,    29,     0,     0,     0,    32,     0,
+      36,    20,    22,     0,     0,     0,    25,     0,    28,     0,
+      31,     0,    35,     0,     0,     0,     0,    27,    30,     0,
+      33,     0,    37,     0,     0,     0,     0,     0,    34,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+      38,     0,    39
 };
 
   /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
-      -9,    -9,    -9,    43,    -9,    -9,    -7,    -9,    -8,    -9,
-      -9,    -9,    -9,    -9,    -9,    -9,    19,    -9,    -9,    18
+     -10,   -10,   -10,    63,   -10,   -10,    -8,   -10,    -9,   -10,
+     -10,   -10,   -10,   -10,   -10,   -10,     2,   -10,   -10,    19
 };
 
   /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int8 yydefgoto[] =
 {
-      -1,     2,     4,     5,    18,    19,    44,    21,    22,    23,
-      24,    34,    25,    35,    26,    36,    37,    27,    38,    39
+      -1,     2,     5,     6,    19,    20,    45,    22,    23,    24,
+      25,    35,    26,    36,    27,    37,    38,    28,    39,    40
 };
 
   /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
      positive, shift that token.  If negative, reduce the rule whose
      number is the opposite.  If YYTABLE_NINF, syntax error.  */
-static const yytype_uint8 yytable[] =
+static const yytype_int8 yytable[] =
 {
-      20,    10,    33,    32,    42,    11,    12,    13,    14,    15,
-      16,    17,    29,    30,    43,    42,    31,    31,     3,    31,
-      15,    15,    17,    15,     8,    43,     1,     9,    40,    41,
-      45,    46,    47,    48,    49,    50,    51,    52,     6,    56,
-      57,     7,    40,    54,    55,    58,    53,    63,    64,    17,
-      60,    62,    28,    66,    67,    65,    68,    71,    69,    72,
-      70,    74,    75,    78,    73,    79,    81,    76,    77,    59,
-      61,    80
+      21,     3,    34,    33,    32,    46,    47,     9,    16,    11,
+      10,     1,     4,    12,    13,    14,    15,    16,    17,    18,
+      30,    31,    43,    43,    32,    41,    42,    32,    16,     7,
+      18,    16,    44,    44,    48,    49,    50,    51,     4,    57,
+      58,    52,    53,    59,     8,    41,    54,    64,    65,    55,
+      56,    61,    18,    60,    63,    66,    67,    68,    70,    69,
+      71,    72,    73,    80,    74,    75,    76,    77,    78,    79,
+      82,    81,    62,    29
 };
 
-static const yytype_uint8 yycheck[] =
+static const yytype_int8 yycheck[] =
 {
-       7,     5,    10,    10,     5,     9,    10,    11,    12,    13,
-      14,    15,     5,     6,    15,     5,     9,     9,    15,     9,
-      13,    13,    15,    13,     4,    15,     3,     7,    13,    14,
-       6,     7,     6,     7,     6,     7,     6,     7,     0,    46,
-      48,     8,    13,     7,     7,     5,    15,    54,    55,    15,
-       5,     7,     9,     7,     6,    62,     7,     7,    66,     6,
-      68,     7,     7,     7,    71,     6,     6,    74,    75,    50,
-      52,    78
+       8,     4,    11,    11,     9,     6,     7,     4,    13,     5,
+       7,     3,    15,     9,    10,    11,    12,    13,    14,    15,
+       5,     6,     5,     5,     9,    13,    14,     9,    13,     0,
+      15,    13,    15,    15,     6,     7,     6,     7,    15,    47,
+      49,     6,     7,     5,     8,    13,    15,    55,    56,     7,
+       7,     5,    15,    51,     7,    63,     7,     6,    67,     7,
+      69,     7,     6,     6,    72,     7,     7,    75,    76,     7,
+       6,    79,    53,    10
 };
 
   /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
      symbol of state STATE-NUM.  */
-static const yytype_uint8 yystos[] =
+static const yytype_int8 yystos[] =
 {
-       0,     3,    17,    15,    18,    19,     0,     8,     4,     7,
-       5,     9,    10,    11,    12,    13,    14,    15,    20,    21,
-      22,    23,    24,    25,    26,    28,    30,    33,    19,     5,
-       6,     9,    22,    24,    27,    29,    31,    32,    34,    35,
-      13,    14,     5,    15,    22,     6,     7,     6,     7,     6,
-       7,     6,     7,    15,     7,     7,    22,    24,     5,    32,
-       5,    35,     7,    22,    22,    22,     7,     6,     7,    24,
-      24,     7,     6,    22,     7,     7,    22,    22,     7,     6,
-      22,     6
+       0,     3,    17,     4,    15,    18,    19,     0,     8,     4,
+       7,     5,     9,    10,    11,    12,    13,    14,    15,    20,
+      21,    22,    23,    24,    25,    26,    28,    30,    33,    19,
+       5,     6,     9,    22,    24,    27,    29,    31,    32,    34,
+      35,    13,    14,     5,    15,    22,     6,     7,     6,     7,
+       6,     7,     6,     7,    15,     7,     7,    22,    24,     5,
+      32,     5,    35,     7,    22,    22,    22,     7,     6,     7,
+      24,    24,     7,     6,    22,     7,     7,    22,    22,     7,
+       6,    22,     6
 };
 
   /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
-static const yytype_uint8 yyr1[] =
+static const yytype_int8 yyr1[] =
 {
-       0,    16,    17,    18,    18,    19,    19,    20,    20,    20,
-      20,    20,    20,    20,    20,    20,    21,    21,    22,    22,
-      23,    23,    24,    25,    26,    27,    27,    28,    29,    29,
-      30,    31,    31,    32,    33,    34,    34,    35,    35
+       0,    16,    17,    17,    18,    18,    19,    19,    20,    20,
+      20,    20,    20,    20,    20,    20,    20,    21,    21,    22,
+      22,    23,    23,    24,    25,    26,    27,    27,    28,    29,
+      29,    30,    31,    31,    32,    33,    34,    34,    35,    35
 };
 
   /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
-static const yytype_uint8 yyr2[] =
+static const yytype_int8 yyr2[] =
 {
-       0,     2,     3,     1,     3,     3,     3,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     2,
-       1,     2,     1,     2,     3,     1,     3,     3,     1,     3,
-       3,     1,     3,     5,     3,     1,     3,    11,    13
+       0,     2,     2,     3,     1,     3,     3,     3,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       2,     1,     2,     1,     2,     3,     1,     3,     3,     1,
+       3,     3,     1,     3,     5,     3,     1,     3,    11,    13
 };
 
 
@@ -669,22 +731,22 @@ static const yytype_uint8 yyr2[] =
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
-#define YYBACKUP(Token, Value)                                  \
-do                                                              \
-  if (yychar == YYEMPTY)                                        \
-    {                                                           \
-      yychar = (Token);                                         \
-      yylval = (Value);                                         \
-      YYPOPSTACK (yylen);                                       \
-      yystate = *yyssp;                                         \
-      goto yybackup;                                            \
-    }                                                           \
-  else                                                          \
-    {                                                           \
-      yyerror (scanner, YY_("syntax error: cannot back up")); \
-      YYERROR;                                                  \
-    }                                                           \
-while (0)
+#define YYBACKUP(Token, Value)                                    \
+  do                                                              \
+    if (yychar == YYEMPTY)                                        \
+      {                                                           \
+        yychar = (Token);                                         \
+        yylval = (Value);                                         \
+        YYPOPSTACK (yylen);                                       \
+        yystate = *yyssp;                                         \
+        goto yybackup;                                            \
+      }                                                           \
+    else                                                          \
+      {                                                           \
+        yyerror (scanner, YY_("syntax error: cannot back up")); \
+        YYERROR;                                                  \
+      }                                                           \
+  while (0)
 
 /* Error token number */
 #define YYTERROR        1
@@ -724,133 +786,134 @@ do {                                                                      \
 } while (0)
 
 
-/*----------------------------------------.
-| Print this symbol's value on YYOUTPUT.  |
-`----------------------------------------*/
+/*-----------------------------------.
+| Print this symbol's value on YYO.  |
+`-----------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, void *scanner)
+yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, void *scanner)
 {
-  FILE *yyo = yyoutput;
-  YYUSE (yyo);
+  FILE *yyoutput = yyo;
+  YYUSE (yyoutput);
   YYUSE (scanner);
   if (!yyvaluep)
     return;
 # ifdef YYPRINT
   if (yytype < YYNTOKENS)
-    YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
+    YYPRINT (yyo, yytoknum[yytype], *yyvaluep);
 # endif
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   switch (yytype)
     {
-          case 13: /* EVENT_INTEGER  */
-#line 83 "src/event_parser.y" /* yacc.c:684  */
-      { fprintf(yyoutput, "%lld", ((*yyvaluep).integer_value)); }
-#line 749 "src/event_parser.c" /* yacc.c:684  */
+    case 13: /* EVENT_INTEGER  */
+#line 83 "src/event_parser.y"
+         { fprintf(yyoutput, "%lld", ((*yyvaluep).integer_value)); }
+#line 812 "src/event_parser.c"
         break;
 
     case 14: /* EVENT_FLOAT  */
-#line 84 "src/event_parser.y" /* yacc.c:684  */
-      { fprintf(yyoutput, "%.2f", ((*yyvaluep).float_value)); }
-#line 755 "src/event_parser.c" /* yacc.c:684  */
+#line 84 "src/event_parser.y"
+         { fprintf(yyoutput, "%.2f", ((*yyvaluep).float_value)); }
+#line 818 "src/event_parser.c"
         break;
 
     case 15: /* EVENT_STRING  */
-#line 85 "src/event_parser.y" /* yacc.c:684  */
-      { fprintf(yyoutput, "%s", ((*yyvaluep).string)); }
-#line 761 "src/event_parser.c" /* yacc.c:684  */
+#line 85 "src/event_parser.y"
+         { fprintf(yyoutput, "%s", ((*yyvaluep).string)); }
+#line 824 "src/event_parser.c"
         break;
 
     case 22: /* integer  */
-#line 83 "src/event_parser.y" /* yacc.c:684  */
-      { fprintf(yyoutput, "%lld", ((*yyvaluep).integer_value)); }
-#line 767 "src/event_parser.c" /* yacc.c:684  */
+#line 83 "src/event_parser.y"
+         { fprintf(yyoutput, "%lld", ((*yyvaluep).integer_value)); }
+#line 830 "src/event_parser.c"
         break;
 
     case 23: /* float  */
-#line 84 "src/event_parser.y" /* yacc.c:684  */
-      { fprintf(yyoutput, "%.2f", ((*yyvaluep).float_value)); }
-#line 773 "src/event_parser.c" /* yacc.c:684  */
+#line 84 "src/event_parser.y"
+         { fprintf(yyoutput, "%.2f", ((*yyvaluep).float_value)); }
+#line 836 "src/event_parser.c"
         break;
 
     case 24: /* string  */
-#line 86 "src/event_parser.y" /* yacc.c:684  */
-      { fprintf(yyoutput, "%s", ((*yyvaluep).string_value).string); }
-#line 779 "src/event_parser.c" /* yacc.c:684  */
+#line 86 "src/event_parser.y"
+         { fprintf(yyoutput, "%s", ((*yyvaluep).string_value).string); }
+#line 842 "src/event_parser.c"
         break;
 
     case 25: /* empty_list_value  */
-#line 87 "src/event_parser.y" /* yacc.c:684  */
-      { fprintf(yyoutput, "%zu integers", ((*yyvaluep).integer_list_value).count); }
-#line 785 "src/event_parser.c" /* yacc.c:684  */
+#line 87 "src/event_parser.y"
+         { fprintf(yyoutput, "%zu integers", ((*yyvaluep).integer_list_value).count); }
+#line 848 "src/event_parser.c"
         break;
 
     case 26: /* integer_list_value  */
-#line 87 "src/event_parser.y" /* yacc.c:684  */
-      { fprintf(yyoutput, "%zu integers", ((*yyvaluep).integer_list_value).count); }
-#line 791 "src/event_parser.c" /* yacc.c:684  */
+#line 87 "src/event_parser.y"
+         { fprintf(yyoutput, "%zu integers", ((*yyvaluep).integer_list_value).count); }
+#line 854 "src/event_parser.c"
         break;
 
     case 27: /* integer_list_loop  */
-#line 87 "src/event_parser.y" /* yacc.c:684  */
-      { fprintf(yyoutput, "%zu integers", ((*yyvaluep).integer_list_value).count); }
-#line 797 "src/event_parser.c" /* yacc.c:684  */
+#line 87 "src/event_parser.y"
+         { fprintf(yyoutput, "%zu integers", ((*yyvaluep).integer_list_value).count); }
+#line 860 "src/event_parser.c"
         break;
 
     case 28: /* string_list_value  */
-#line 88 "src/event_parser.y" /* yacc.c:684  */
-      { fprintf(yyoutput, "%zu strings", ((*yyvaluep).string_list_value).count); }
-#line 803 "src/event_parser.c" /* yacc.c:684  */
+#line 88 "src/event_parser.y"
+         { fprintf(yyoutput, "%zu strings", ((*yyvaluep).string_list_value).count); }
+#line 866 "src/event_parser.c"
         break;
 
     case 29: /* string_list_loop  */
-#line 88 "src/event_parser.y" /* yacc.c:684  */
-      { fprintf(yyoutput, "%zu strings", ((*yyvaluep).string_list_value).count); }
-#line 809 "src/event_parser.c" /* yacc.c:684  */
+#line 88 "src/event_parser.y"
+         { fprintf(yyoutput, "%zu strings", ((*yyvaluep).string_list_value).count); }
+#line 872 "src/event_parser.c"
         break;
 
     case 30: /* segments_value  */
-#line 89 "src/event_parser.y" /* yacc.c:684  */
-      { fprintf(yyoutput, "%zu segments", ((*yyvaluep).segments_list_value).size); }
-#line 815 "src/event_parser.c" /* yacc.c:684  */
+#line 89 "src/event_parser.y"
+         { fprintf(yyoutput, "%zu segments", ((*yyvaluep).segments_list_value).size); }
+#line 878 "src/event_parser.c"
         break;
 
     case 31: /* segments_loop  */
-#line 89 "src/event_parser.y" /* yacc.c:684  */
-      { fprintf(yyoutput, "%zu segments", ((*yyvaluep).segments_list_value).size); }
-#line 821 "src/event_parser.c" /* yacc.c:684  */
+#line 89 "src/event_parser.y"
+         { fprintf(yyoutput, "%zu segments", ((*yyvaluep).segments_list_value).size); }
+#line 884 "src/event_parser.c"
         break;
 
     case 33: /* frequencies_value  */
-#line 90 "src/event_parser.y" /* yacc.c:684  */
-      { fprintf(yyoutput, "%zu caps", ((*yyvaluep).frequencies_value).size); }
-#line 827 "src/event_parser.c" /* yacc.c:684  */
+#line 90 "src/event_parser.y"
+         { fprintf(yyoutput, "%zu caps", ((*yyvaluep).frequencies_value).size); }
+#line 890 "src/event_parser.c"
         break;
 
     case 34: /* frequencies_loop  */
-#line 90 "src/event_parser.y" /* yacc.c:684  */
-      { fprintf(yyoutput, "%zu caps", ((*yyvaluep).frequencies_value).size); }
-#line 833 "src/event_parser.c" /* yacc.c:684  */
+#line 90 "src/event_parser.y"
+         { fprintf(yyoutput, "%zu caps", ((*yyvaluep).frequencies_value).size); }
+#line 896 "src/event_parser.c"
         break;
-
 
       default:
         break;
     }
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+/*---------------------------.
+| Print this symbol on YYO.  |
+`---------------------------*/
 
 static void
-yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, void *scanner)
+yy_symbol_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep, void *scanner)
 {
-  YYFPRINTF (yyoutput, "%s %s (",
+  YYFPRINTF (yyo, "%s %s (",
              yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
 
-  yy_symbol_value_print (yyoutput, yytype, yyvaluep, scanner);
-  YYFPRINTF (yyoutput, ")");
+  yy_symbol_value_print (yyo, yytype, yyvaluep, scanner);
+  YYFPRINTF (yyo, ")");
 }
 
 /*------------------------------------------------------------------.
@@ -859,7 +922,7 @@ yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, voi
 `------------------------------------------------------------------*/
 
 static void
-yy_stack_print (yytype_int16 *yybottom, yytype_int16 *yytop)
+yy_stack_print (yy_state_t *yybottom, yy_state_t *yytop)
 {
   YYFPRINTF (stderr, "Stack now");
   for (; yybottom <= yytop; yybottom++)
@@ -882,20 +945,20 @@ do {                                                            \
 `------------------------------------------------*/
 
 static void
-yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule, void *scanner)
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, int yyrule, void *scanner)
 {
-  unsigned long int yylno = yyrline[yyrule];
+  int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
-  YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
+  YYFPRINTF (stderr, "Reducing stack by rule %d (line %d):\n",
              yyrule - 1, yylno);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr,
-                       yystos[yyssp[yyi + 1 - yynrhs]],
-                       &(yyvsp[(yyi + 1) - (yynrhs)])
+                       yystos[+yyssp[yyi + 1 - yynrhs]],
+                       &yyvsp[(yyi + 1) - (yynrhs)]
                                               , scanner);
       YYFPRINTF (stderr, "\n");
     }
@@ -939,13 +1002,13 @@ int yydebug;
 
 # ifndef yystrlen
 #  if defined __GLIBC__ && defined _STRING_H
-#   define yystrlen strlen
+#   define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
 #  else
 /* Return the length of YYSTR.  */
-static YYSIZE_T
+static YYPTRDIFF_T
 yystrlen (const char *yystr)
 {
-  YYSIZE_T yylen;
+  YYPTRDIFF_T yylen;
   for (yylen = 0; yystr[yylen]; yylen++)
     continue;
   return yylen;
@@ -981,12 +1044,12 @@ yystpcpy (char *yydest, const char *yysrc)
    backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
    null, do not copy; instead, return the length of what the result
    would have been.  */
-static YYSIZE_T
+static YYPTRDIFF_T
 yytnamerr (char *yyres, const char *yystr)
 {
   if (*yystr == '"')
     {
-      YYSIZE_T yyn = 0;
+      YYPTRDIFF_T yyn = 0;
       char const *yyp = yystr;
 
       for (;;)
@@ -999,7 +1062,10 @@ yytnamerr (char *yyres, const char *yystr)
           case '\\':
             if (*++yyp != '\\')
               goto do_not_strip_quotes;
-            /* Fall through.  */
+            else
+              goto append;
+
+          append:
           default:
             if (yyres)
               yyres[yyn] = *yyp;
@@ -1014,10 +1080,10 @@ yytnamerr (char *yyres, const char *yystr)
     do_not_strip_quotes: ;
     }
 
-  if (! yyres)
+  if (yyres)
+    return yystpcpy (yyres, yystr) - yyres;
+  else
     return yystrlen (yystr);
-
-  return yystpcpy (yyres, yystr) - yyres;
 }
 # endif
 
@@ -1030,19 +1096,19 @@ yytnamerr (char *yyres, const char *yystr)
    *YYMSG_ALLOC to the required number of bytes.  Return 2 if the
    required number of bytes is too large to store.  */
 static int
-yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
-                yytype_int16 *yyssp, int yytoken)
+yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
+                yy_state_t *yyssp, int yytoken)
 {
-  YYSIZE_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
-  YYSIZE_T yysize = yysize0;
   enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
   /* Internationalized format string. */
   const char *yyformat = YY_NULLPTR;
-  /* Arguments of yyformat. */
+  /* Arguments of yyformat: reported tokens (one for the "unexpected",
+     one per "expected"). */
   char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-  /* Number of reported tokens (one for the "unexpected", one per
-     "expected"). */
+  /* Actual size of YYARG. */
   int yycount = 0;
+  /* Cumulated lengths of YYARG.  */
+  YYPTRDIFF_T yysize = 0;
 
   /* There are many possibilities here to consider:
      - If this state is a consistent state with a default action, then
@@ -1069,7 +1135,9 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
   */
   if (yytoken != YYEMPTY)
     {
-      int yyn = yypact[*yyssp];
+      int yyn = yypact[+*yyssp];
+      YYPTRDIFF_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
+      yysize = yysize0;
       yyarg[yycount++] = yytname[yytoken];
       if (!yypact_value_is_default (yyn))
         {
@@ -1094,11 +1162,12 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
                   }
                 yyarg[yycount++] = yytname[yyx];
                 {
-                  YYSIZE_T yysize1 = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
-                  if (! (yysize <= yysize1
-                         && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
+                  YYPTRDIFF_T yysize1
+                    = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
+                  if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
+                    yysize = yysize1;
+                  else
                     return 2;
-                  yysize = yysize1;
                 }
               }
         }
@@ -1110,6 +1179,7 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
       case N:                               \
         yyformat = S;                       \
       break
+    default: /* Avoid compiler warnings. */
       YYCASE_(0, YY_("syntax error"));
       YYCASE_(1, YY_("syntax error, unexpected %s"));
       YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
@@ -1120,10 +1190,13 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
     }
 
   {
-    YYSIZE_T yysize1 = yysize + yystrlen (yyformat);
-    if (! (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
+    /* Don't count the "%s"s in the final size, but reserve room for
+       the terminator.  */
+    YYPTRDIFF_T yysize1 = yysize + (yystrlen (yyformat) - 2 * yycount) + 1;
+    if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
+      yysize = yysize1;
+    else
       return 2;
-    yysize = yysize1;
   }
 
   if (*yymsg_alloc < yysize)
@@ -1149,8 +1222,8 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
         }
       else
         {
-          yyp++;
-          yyformat++;
+          ++yyp;
+          ++yyformat;
         }
   }
   return 0;
@@ -1198,7 +1271,7 @@ YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
     /* Number of syntax errors so far.  */
     int yynerrs;
 
-    int yystate;
+    yy_state_fast_t yystate;
     /* Number of tokens to shift before error messages enabled.  */
     int yyerrstatus;
 
@@ -1210,16 +1283,16 @@ YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
        to reallocate them elsewhere.  */
 
     /* The state stack.  */
-    yytype_int16 yyssa[YYINITDEPTH];
-    yytype_int16 *yyss;
-    yytype_int16 *yyssp;
+    yy_state_t yyssa[YYINITDEPTH];
+    yy_state_t *yyss;
+    yy_state_t *yyssp;
 
     /* The semantic value stack.  */
     YYSTYPE yyvsa[YYINITDEPTH];
     YYSTYPE *yyvs;
     YYSTYPE *yyvsp;
 
-    YYSIZE_T yystacksize;
+    YYPTRDIFF_T yystacksize;
 
   int yyn;
   int yyresult;
@@ -1233,7 +1306,7 @@ YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
   /* Buffer for error messages, and its allocated size.  */
   char yymsgbuf[128];
   char *yymsg = yymsgbuf;
-  YYSIZE_T yymsg_alloc = sizeof yymsgbuf;
+  YYPTRDIFF_T yymsg_alloc = sizeof yymsgbuf;
 #endif
 
 #define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N))
@@ -1254,46 +1327,54 @@ YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
   yychar = YYEMPTY; /* Cause a token to be read.  */
   goto yysetstate;
 
+
 /*------------------------------------------------------------.
-| yynewstate -- Push a new state, which is found in yystate.  |
+| yynewstate -- push a new state, which is found in yystate.  |
 `------------------------------------------------------------*/
- yynewstate:
+yynewstate:
   /* In all cases, when you get here, the value and location stacks
      have just been pushed.  So pushing a state here evens the stacks.  */
   yyssp++;
 
- yysetstate:
-  *yyssp = yystate;
+
+/*--------------------------------------------------------------------.
+| yysetstate -- set current state (the top of the stack) to yystate.  |
+`--------------------------------------------------------------------*/
+yysetstate:
+  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+  YY_ASSERT (0 <= yystate && yystate < YYNSTATES);
+  YY_IGNORE_USELESS_CAST_BEGIN
+  *yyssp = YY_CAST (yy_state_t, yystate);
+  YY_IGNORE_USELESS_CAST_END
 
   if (yyss + yystacksize - 1 <= yyssp)
+#if !defined yyoverflow && !defined YYSTACK_RELOCATE
+    goto yyexhaustedlab;
+#else
     {
       /* Get the current used size of the three stacks, in elements.  */
-      YYSIZE_T yysize = yyssp - yyss + 1;
+      YYPTRDIFF_T yysize = yyssp - yyss + 1;
 
-#ifdef yyoverflow
+# if defined yyoverflow
       {
         /* Give user a chance to reallocate the stack.  Use copies of
            these so that the &'s don't force the real ones into
            memory.  */
+        yy_state_t *yyss1 = yyss;
         YYSTYPE *yyvs1 = yyvs;
-        yytype_int16 *yyss1 = yyss;
 
         /* Each stack pointer address is followed by the size of the
            data in use in that stack, in bytes.  This used to be a
            conditional around just the two extra args, but that might
            be undefined if yyoverflow is a macro.  */
         yyoverflow (YY_("memory exhausted"),
-                    &yyss1, yysize * sizeof (*yyssp),
-                    &yyvs1, yysize * sizeof (*yyvsp),
+                    &yyss1, yysize * YYSIZEOF (*yyssp),
+                    &yyvs1, yysize * YYSIZEOF (*yyvsp),
                     &yystacksize);
-
         yyss = yyss1;
         yyvs = yyvs1;
       }
-#else /* no yyoverflow */
-# ifndef YYSTACK_RELOCATE
-      goto yyexhaustedlab;
-# else
+# else /* defined YYSTACK_RELOCATE */
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
         goto yyexhaustedlab;
@@ -1302,42 +1383,43 @@ YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
         yystacksize = YYMAXDEPTH;
 
       {
-        yytype_int16 *yyss1 = yyss;
+        yy_state_t *yyss1 = yyss;
         union yyalloc *yyptr =
-          (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
+          YY_CAST (union yyalloc *,
+                   YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
         if (! yyptr)
           goto yyexhaustedlab;
         YYSTACK_RELOCATE (yyss_alloc, yyss);
         YYSTACK_RELOCATE (yyvs_alloc, yyvs);
-#  undef YYSTACK_RELOCATE
+# undef YYSTACK_RELOCATE
         if (yyss1 != yyssa)
           YYSTACK_FREE (yyss1);
       }
 # endif
-#endif /* no yyoverflow */
 
       yyssp = yyss + yysize - 1;
       yyvsp = yyvs + yysize - 1;
 
-      YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-                  (unsigned long int) yystacksize));
+      YY_IGNORE_USELESS_CAST_BEGIN
+      YYDPRINTF ((stderr, "Stack size increased to %ld\n",
+                  YY_CAST (long, yystacksize)));
+      YY_IGNORE_USELESS_CAST_END
 
       if (yyss + yystacksize - 1 <= yyssp)
         YYABORT;
     }
-
-  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+#endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
 
   if (yystate == YYFINAL)
     YYACCEPT;
 
   goto yybackup;
 
+
 /*-----------.
 | yybackup.  |
 `-----------*/
 yybackup:
-
   /* Do appropriate processing given the current state.  Read a
      lookahead token if we need one and don't already have one.  */
 
@@ -1387,15 +1469,13 @@ yybackup:
 
   /* Shift the lookahead token.  */
   YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
-
-  /* Discard the shifted token.  */
-  yychar = YYEMPTY;
-
   yystate = yyn;
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 
+  /* Discard the shifted token.  */
+  yychar = YYEMPTY;
   goto yynewstate;
 
 
@@ -1410,7 +1490,7 @@ yydefault:
 
 
 /*-----------------------------.
-| yyreduce -- Do a reduction.  |
+| yyreduce -- do a reduction.  |
 `-----------------------------*/
 yyreduce:
   /* yyn is the number of a rule to reduce with.  */
@@ -1430,230 +1510,237 @@ yyreduce:
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-        case 2:
-#line 94 "src/event_parser.y" /* yacc.c:1646  */
-    { root = (yyvsp[-1].event); }
-#line 1437 "src/event_parser.c" /* yacc.c:1646  */
+  case 2:
+#line 94 "src/event_parser.y"
+                                                                { root = make_empty_event(); }
+#line 1517 "src/event_parser.c"
     break;
 
   case 3:
-#line 96 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.event) = make_empty_event(); add_variable((yyvsp[0].variable), (yyval.event)); }
-#line 1443 "src/event_parser.c" /* yacc.c:1646  */
+#line 95 "src/event_parser.y"
+                                                                { root = (yyvsp[-1].event); }
+#line 1523 "src/event_parser.c"
     break;
 
   case 4:
-#line 97 "src/event_parser.y" /* yacc.c:1646  */
-    { add_variable((yyvsp[0].variable), (yyvsp[-2].event)); (yyval.event) = (yyvsp[-2].event); }
-#line 1449 "src/event_parser.c" /* yacc.c:1646  */
+#line 98 "src/event_parser.y"
+                                                            { (yyval.event) = make_empty_event(); add_variable((yyvsp[0].variable), (yyval.event)); }
+#line 1529 "src/event_parser.c"
     break;
 
   case 5:
-#line 100 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.variable) = make_pred((yyvsp[-2].string), INVALID_VAR, (yyvsp[0].value)); bfree((yyvsp[-2].string)); }
-#line 1455 "src/event_parser.c" /* yacc.c:1646  */
+#line 99 "src/event_parser.y"
+                                                            { add_variable((yyvsp[0].variable), (yyvsp[-2].event)); (yyval.event) = (yyvsp[-2].event); }
+#line 1535 "src/event_parser.c"
     break;
 
   case 6:
-#line 101 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.variable) = NULL; bfree((yyvsp[-2].string)); }
-#line 1461 "src/event_parser.c" /* yacc.c:1646  */
+#line 102 "src/event_parser.y"
+                                                            { (yyval.variable) = make_pred((yyvsp[-2].string), INVALID_VAR, (yyvsp[0].value)); bfree((yyvsp[-2].string)); }
+#line 1541 "src/event_parser.c"
     break;
 
   case 7:
-#line 104 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.value).value_type = BETREE_BOOLEAN; (yyval.value).boolean_value = (yyvsp[0].boolean_value); }
-#line 1467 "src/event_parser.c" /* yacc.c:1646  */
+#line 103 "src/event_parser.y"
+                                                            { (yyval.variable) = NULL; bfree((yyvsp[-2].string)); }
+#line 1547 "src/event_parser.c"
     break;
 
   case 8:
-#line 105 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.value).value_type = BETREE_INTEGER; (yyval.value).integer_value = (yyvsp[0].integer_value); }
-#line 1473 "src/event_parser.c" /* yacc.c:1646  */
+#line 106 "src/event_parser.y"
+                                                            { (yyval.value).value_type = BETREE_BOOLEAN; (yyval.value).boolean_value = (yyvsp[0].boolean_value); }
+#line 1553 "src/event_parser.c"
     break;
 
   case 9:
-#line 106 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.value).value_type = BETREE_FLOAT; (yyval.value).float_value = (yyvsp[0].float_value); }
-#line 1479 "src/event_parser.c" /* yacc.c:1646  */
+#line 107 "src/event_parser.y"
+                                                            { (yyval.value).value_type = BETREE_INTEGER; (yyval.value).integer_value = (yyvsp[0].integer_value); }
+#line 1559 "src/event_parser.c"
     break;
 
   case 10:
-#line 107 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.value).value_type = BETREE_STRING; (yyval.value).string_value = (yyvsp[0].string_value); }
-#line 1485 "src/event_parser.c" /* yacc.c:1646  */
+#line 108 "src/event_parser.y"
+                                                            { (yyval.value).value_type = BETREE_FLOAT; (yyval.value).float_value = (yyvsp[0].float_value); }
+#line 1565 "src/event_parser.c"
     break;
 
   case 11:
-#line 108 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.value).value_type = BETREE_INTEGER_LIST; (yyval.value).integer_list_value = (yyvsp[0].integer_list_value); }
-#line 1491 "src/event_parser.c" /* yacc.c:1646  */
+#line 109 "src/event_parser.y"
+                                                            { (yyval.value).value_type = BETREE_STRING; (yyval.value).string_value = (yyvsp[0].string_value); }
+#line 1571 "src/event_parser.c"
     break;
 
   case 12:
-#line 109 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.value).value_type = BETREE_INTEGER_LIST; (yyval.value).integer_list_value = (yyvsp[0].integer_list_value); }
-#line 1497 "src/event_parser.c" /* yacc.c:1646  */
+#line 110 "src/event_parser.y"
+                                                            { (yyval.value).value_type = BETREE_INTEGER_LIST; (yyval.value).integer_list_value = (yyvsp[0].integer_list_value); }
+#line 1577 "src/event_parser.c"
     break;
 
   case 13:
-#line 110 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.value).value_type = BETREE_STRING_LIST; (yyval.value).string_list_value = (yyvsp[0].string_list_value); }
-#line 1503 "src/event_parser.c" /* yacc.c:1646  */
+#line 111 "src/event_parser.y"
+                                                            { (yyval.value).value_type = BETREE_INTEGER_LIST; (yyval.value).integer_list_value = (yyvsp[0].integer_list_value); }
+#line 1583 "src/event_parser.c"
     break;
 
   case 14:
-#line 111 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.value).value_type = BETREE_SEGMENTS; (yyval.value).segments_value = (yyvsp[0].segments_list_value); }
-#line 1509 "src/event_parser.c" /* yacc.c:1646  */
+#line 112 "src/event_parser.y"
+                                                            { (yyval.value).value_type = BETREE_STRING_LIST; (yyval.value).string_list_value = (yyvsp[0].string_list_value); }
+#line 1589 "src/event_parser.c"
     break;
 
   case 15:
-#line 112 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.value).value_type = BETREE_FREQUENCY_CAPS; (yyval.value).frequency_caps_value = (yyvsp[0].frequencies_value); }
-#line 1515 "src/event_parser.c" /* yacc.c:1646  */
+#line 113 "src/event_parser.y"
+                                                            { (yyval.value).value_type = BETREE_SEGMENTS; (yyval.value).segments_value = (yyvsp[0].segments_list_value); }
+#line 1595 "src/event_parser.c"
     break;
 
   case 16:
-#line 114 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.boolean_value) = true; }
-#line 1521 "src/event_parser.c" /* yacc.c:1646  */
+#line 114 "src/event_parser.y"
+                                                            { (yyval.value).value_type = BETREE_FREQUENCY_CAPS; (yyval.value).frequency_caps_value = (yyvsp[0].frequencies_value); }
+#line 1601 "src/event_parser.c"
     break;
 
   case 17:
-#line 115 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.boolean_value) = false; }
-#line 1527 "src/event_parser.c" /* yacc.c:1646  */
+#line 116 "src/event_parser.y"
+                                                            { (yyval.boolean_value) = true; }
+#line 1607 "src/event_parser.c"
     break;
 
   case 18:
-#line 118 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.integer_value) = (yyvsp[0].integer_value); }
-#line 1533 "src/event_parser.c" /* yacc.c:1646  */
+#line 117 "src/event_parser.y"
+                                                            { (yyval.boolean_value) = false; }
+#line 1613 "src/event_parser.c"
     break;
 
   case 19:
-#line 119 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.integer_value) = - (yyvsp[0].integer_value); }
-#line 1539 "src/event_parser.c" /* yacc.c:1646  */
+#line 120 "src/event_parser.y"
+                                                            { (yyval.integer_value) = (yyvsp[0].integer_value); }
+#line 1619 "src/event_parser.c"
     break;
 
   case 20:
-#line 122 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.float_value) = (yyvsp[0].float_value); }
-#line 1545 "src/event_parser.c" /* yacc.c:1646  */
+#line 121 "src/event_parser.y"
+                                                            { (yyval.integer_value) = - (yyvsp[0].integer_value); }
+#line 1625 "src/event_parser.c"
     break;
 
   case 21:
-#line 123 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.float_value) = - (yyvsp[0].float_value); }
-#line 1551 "src/event_parser.c" /* yacc.c:1646  */
+#line 124 "src/event_parser.y"
+                                                            { (yyval.float_value) = (yyvsp[0].float_value); }
+#line 1631 "src/event_parser.c"
     break;
 
   case 22:
-#line 126 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.string_value).string = bstrdup((yyvsp[0].string)); (yyval.string_value).str = INVALID_STR; bfree((yyvsp[0].string)); }
-#line 1557 "src/event_parser.c" /* yacc.c:1646  */
+#line 125 "src/event_parser.y"
+                                                            { (yyval.float_value) = - (yyvsp[0].float_value); }
+#line 1637 "src/event_parser.c"
     break;
 
   case 23:
-#line 128 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.integer_list_value) = make_integer_list(); }
-#line 1563 "src/event_parser.c" /* yacc.c:1646  */
+#line 128 "src/event_parser.y"
+                                                            { (yyval.string_value).string = bstrdup((yyvsp[0].string)); (yyval.string_value).str = INVALID_STR; bfree((yyvsp[0].string)); }
+#line 1643 "src/event_parser.c"
     break;
 
   case 24:
-#line 131 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.integer_list_value) = (yyvsp[-1].integer_list_value); }
-#line 1569 "src/event_parser.c" /* yacc.c:1646  */
+#line 130 "src/event_parser.y"
+                                                            { (yyval.integer_list_value) = make_integer_list(); }
+#line 1649 "src/event_parser.c"
     break;
 
   case 25:
-#line 133 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.integer_list_value) = make_integer_list(); add_integer_list_value((yyvsp[0].integer_value), (yyval.integer_list_value)); }
-#line 1575 "src/event_parser.c" /* yacc.c:1646  */
+#line 133 "src/event_parser.y"
+                                                            { (yyval.integer_list_value) = (yyvsp[-1].integer_list_value); }
+#line 1655 "src/event_parser.c"
     break;
 
   case 26:
-#line 134 "src/event_parser.y" /* yacc.c:1646  */
-    { add_integer_list_value((yyvsp[0].integer_value), (yyvsp[-2].integer_list_value)); (yyval.integer_list_value) = (yyvsp[-2].integer_list_value); }
-#line 1581 "src/event_parser.c" /* yacc.c:1646  */
+#line 135 "src/event_parser.y"
+                                                            { (yyval.integer_list_value) = make_integer_list(); add_integer_list_value((yyvsp[0].integer_value), (yyval.integer_list_value)); }
+#line 1661 "src/event_parser.c"
     break;
 
   case 27:
-#line 138 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.string_list_value) = (yyvsp[-1].string_list_value); }
-#line 1587 "src/event_parser.c" /* yacc.c:1646  */
+#line 136 "src/event_parser.y"
+                                                            { add_integer_list_value((yyvsp[0].integer_value), (yyvsp[-2].integer_list_value)); (yyval.integer_list_value) = (yyvsp[-2].integer_list_value); }
+#line 1667 "src/event_parser.c"
     break;
 
   case 28:
-#line 140 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.string_list_value) = make_string_list(); add_string_list_value((yyvsp[0].string_value), (yyval.string_list_value)); }
-#line 1593 "src/event_parser.c" /* yacc.c:1646  */
+#line 140 "src/event_parser.y"
+                                                            { (yyval.string_list_value) = (yyvsp[-1].string_list_value); }
+#line 1673 "src/event_parser.c"
     break;
 
   case 29:
-#line 141 "src/event_parser.y" /* yacc.c:1646  */
-    { add_string_list_value((yyvsp[0].string_value), (yyvsp[-2].string_list_value)); (yyval.string_list_value) = (yyvsp[-2].string_list_value); }
-#line 1599 "src/event_parser.c" /* yacc.c:1646  */
+#line 142 "src/event_parser.y"
+                                                            { (yyval.string_list_value) = make_string_list(); add_string_list_value((yyvsp[0].string_value), (yyval.string_list_value)); }
+#line 1679 "src/event_parser.c"
     break;
 
   case 30:
-#line 145 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.segments_list_value) = (yyvsp[-1].segments_list_value); }
-#line 1605 "src/event_parser.c" /* yacc.c:1646  */
+#line 143 "src/event_parser.y"
+                                                            { add_string_list_value((yyvsp[0].string_value), (yyvsp[-2].string_list_value)); (yyval.string_list_value) = (yyvsp[-2].string_list_value); }
+#line 1685 "src/event_parser.c"
     break;
 
   case 31:
-#line 147 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.segments_list_value) = make_segments(); add_segment((yyvsp[0].segment_value), (yyval.segments_list_value)); }
-#line 1611 "src/event_parser.c" /* yacc.c:1646  */
+#line 147 "src/event_parser.y"
+                                                            { (yyval.segments_list_value) = (yyvsp[-1].segments_list_value); }
+#line 1691 "src/event_parser.c"
     break;
 
   case 32:
-#line 149 "src/event_parser.y" /* yacc.c:1646  */
-    { add_segment((yyvsp[0].segment_value), (yyvsp[-2].segments_list_value)); (yyval.segments_list_value) = (yyvsp[-2].segments_list_value); }
-#line 1617 "src/event_parser.c" /* yacc.c:1646  */
+#line 149 "src/event_parser.y"
+                                                            { (yyval.segments_list_value) = make_segments(); add_segment((yyvsp[0].segment_value), (yyval.segments_list_value)); }
+#line 1697 "src/event_parser.c"
     break;
 
   case 33:
-#line 153 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.segment_value) = make_segment((yyvsp[-3].integer_value), (yyvsp[-1].integer_value)); }
-#line 1623 "src/event_parser.c" /* yacc.c:1646  */
+#line 151 "src/event_parser.y"
+                                                            { add_segment((yyvsp[0].segment_value), (yyvsp[-2].segments_list_value)); (yyval.segments_list_value) = (yyvsp[-2].segments_list_value); }
+#line 1703 "src/event_parser.c"
     break;
 
   case 34:
-#line 156 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.frequencies_value) = (yyvsp[-1].frequencies_value); }
-#line 1629 "src/event_parser.c" /* yacc.c:1646  */
+#line 155 "src/event_parser.y"
+                                                            { (yyval.segment_value) = make_segment((yyvsp[-3].integer_value), (yyvsp[-1].integer_value)); }
+#line 1709 "src/event_parser.c"
     break;
 
   case 35:
-#line 158 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.frequencies_value) = make_frequency_caps(); add_frequency((yyvsp[0].frequency_value), (yyval.frequencies_value)); }
-#line 1635 "src/event_parser.c" /* yacc.c:1646  */
+#line 158 "src/event_parser.y"
+                                                            { (yyval.frequencies_value) = (yyvsp[-1].frequencies_value); }
+#line 1715 "src/event_parser.c"
     break;
 
   case 36:
-#line 160 "src/event_parser.y" /* yacc.c:1646  */
-    { add_frequency((yyvsp[0].frequency_value), (yyvsp[-2].frequencies_value)); (yyval.frequencies_value) = (yyvsp[-2].frequencies_value); }
-#line 1641 "src/event_parser.c" /* yacc.c:1646  */
+#line 160 "src/event_parser.y"
+                                                            { (yyval.frequencies_value) = make_frequency_caps(); add_frequency((yyvsp[0].frequency_value), (yyval.frequencies_value)); }
+#line 1721 "src/event_parser.c"
     break;
 
   case 37:
-#line 164 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.frequency_value) = make_frequency_cap((yyvsp[-9].string), (yyvsp[-7].integer_value), (yyvsp[-5].string_value), true, (yyvsp[-1].integer_value), (yyvsp[-3].integer_value)); bfree((yyvsp[-9].string)); }
-#line 1647 "src/event_parser.c" /* yacc.c:1646  */
+#line 162 "src/event_parser.y"
+                                                            { add_frequency((yyvsp[0].frequency_value), (yyvsp[-2].frequencies_value)); (yyval.frequencies_value) = (yyvsp[-2].frequencies_value); }
+#line 1727 "src/event_parser.c"
     break;
 
   case 38:
-#line 166 "src/event_parser.y" /* yacc.c:1646  */
-    { (yyval.frequency_value) = make_frequency_cap((yyvsp[-10].string), (yyvsp[-8].integer_value), (yyvsp[-6].string_value), true, (yyvsp[-1].integer_value), (yyvsp[-3].integer_value)); bfree((yyvsp[-10].string)); }
-#line 1653 "src/event_parser.c" /* yacc.c:1646  */
+#line 166 "src/event_parser.y"
+                                                            { (yyval.frequency_value) = make_frequency_cap((yyvsp[-9].string), (yyvsp[-7].integer_value), (yyvsp[-5].string_value), true, (yyvsp[-1].integer_value), (yyvsp[-3].integer_value)); bfree((yyvsp[-9].string)); }
+#line 1733 "src/event_parser.c"
+    break;
+
+  case 39:
+#line 168 "src/event_parser.y"
+                                                            { (yyval.frequency_value) = make_frequency_cap((yyvsp[-10].string), (yyvsp[-8].integer_value), (yyvsp[-6].string_value), true, (yyvsp[-1].integer_value), (yyvsp[-3].integer_value)); bfree((yyvsp[-10].string)); }
+#line 1739 "src/event_parser.c"
     break;
 
 
-#line 1657 "src/event_parser.c" /* yacc.c:1646  */
+#line 1743 "src/event_parser.c"
+
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -1678,14 +1765,13 @@ yyreduce:
   /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
-
-  yyn = yyr1[yyn];
-
-  yystate = yypgoto[yyn - YYNTOKENS] + *yyssp;
-  if (0 <= yystate && yystate <= YYLAST && yycheck[yystate] == *yyssp)
-    yystate = yytable[yystate];
-  else
-    yystate = yydefgoto[yyn - YYNTOKENS];
+  {
+    const int yylhs = yyr1[yyn] - YYNTOKENS;
+    const int yyi = yypgoto[yylhs] + *yyssp;
+    yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
+               ? yytable[yyi]
+               : yydefgoto[yylhs]);
+  }
 
   goto yynewstate;
 
@@ -1717,7 +1803,7 @@ yyerrlab:
           {
             if (yymsg != yymsgbuf)
               YYSTACK_FREE (yymsg);
-            yymsg = (char *) YYSTACK_ALLOC (yymsg_alloc);
+            yymsg = YY_CAST (char *, YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
             if (!yymsg)
               {
                 yymsg = yymsgbuf;
@@ -1768,12 +1854,10 @@ yyerrlab:
 | yyerrorlab -- error raised explicitly by YYERROR.  |
 `---------------------------------------------------*/
 yyerrorlab:
-
-  /* Pacify compilers like GCC when the user code never invokes
-     YYERROR and the label yyerrorlab therefore never appears in user
-     code.  */
-  if (/*CONSTCOND*/ 0)
-     goto yyerrorlab;
+  /* Pacify compilers when the user code never invokes YYERROR and the
+     label yyerrorlab therefore never appears in user code.  */
+  if (0)
+    YYERROR;
 
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
@@ -1835,12 +1919,14 @@ yyacceptlab:
   yyresult = 0;
   goto yyreturn;
 
+
 /*-----------------------------------.
 | yyabortlab -- YYABORT comes here.  |
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
   goto yyreturn;
+
 
 #if !defined yyoverflow || YYERROR_VERBOSE
 /*-------------------------------------------------.
@@ -1852,6 +1938,10 @@ yyexhaustedlab:
   /* Fall through.  */
 #endif
 
+
+/*-----------------------------------------------------.
+| yyreturn -- parsing is finished, return the result.  |
+`-----------------------------------------------------*/
 yyreturn:
   if (yychar != YYEMPTY)
     {
@@ -1868,7 +1958,7 @@ yyreturn:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  yystos[*yyssp], yyvsp, scanner);
+                  yystos[+*yyssp], yyvsp, scanner);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
@@ -1881,7 +1971,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 169 "src/event_parser.y" /* yacc.c:1906  */
+#line 171 "src/event_parser.y"
 
 
 #if defined(__GNUC__)

--- a/src/event_parser.h
+++ b/src/event_parser.h
@@ -1,8 +1,9 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.5.1.  */
 
 /* Bison interface for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2020 Free Software Foundation,
+   Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -29,6 +30,9 @@
 
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
+
+/* Undocumented macros, especially those whose name start with YY_,
+   are private implementation details.  Do not rely on them.  */
 
 #ifndef YY_ZZ_SRC_EVENT_PARSER_H_INCLUDED
 # define YY_ZZ_SRC_EVENT_PARSER_H_INCLUDED
@@ -68,27 +72,12 @@ extern int zzdebug;
     EVENT_STRING = 270
   };
 #endif
-/* Tokens.  */
-#define EVENT_LCURLY 258
-#define EVENT_RCURLY 259
-#define EVENT_LSQUARE 260
-#define EVENT_RSQUARE 261
-#define EVENT_COMMA 262
-#define EVENT_COLON 263
-#define EVENT_MINUS 264
-#define EVENT_NULL 265
-#define EVENT_TRUE 266
-#define EVENT_FALSE 267
-#define EVENT_INTEGER 268
-#define EVENT_FLOAT 269
-#define EVENT_STRING 270
 
 /* Value type.  */
 #if ! defined ZZSTYPE && ! defined ZZSTYPE_IS_DECLARED
-
 union ZZSTYPE
 {
-#line 32 "src/event_parser.y" /* yacc.c:1909  */
+#line 32 "src/event_parser.y"
 
     int token;
     char *string;
@@ -109,9 +98,9 @@ union ZZSTYPE
 
     struct betree_event* event;
 
-#line 113 "src/event_parser.h" /* yacc.c:1909  */
-};
+#line 102 "src/event_parser.h"
 
+};
 typedef union ZZSTYPE ZZSTYPE;
 # define ZZSTYPE_IS_TRIVIAL 1
 # define ZZSTYPE_IS_DECLARED 1

--- a/src/event_parser.y
+++ b/src/event_parser.y
@@ -91,7 +91,9 @@
 
 %%
 
-program             : EVENT_LCURLY variable_loop EVENT_RCURLY   { root = $2; }
+program             : EVENT_LCURLY EVENT_RCURLY                 { root = make_empty_event(); }
+                    | EVENT_LCURLY variable_loop EVENT_RCURLY   { root = $2; }
+;
 
 variable_loop       : variable                              { $$ = make_empty_event(); add_variable($1, $$); }
                     | variable_loop EVENT_COMMA variable    { add_variable($3, $1); $$ = $1; }

--- a/src/printer.c
+++ b/src/printer.c
@@ -131,14 +131,6 @@ static const char* set_right_value_to_string(struct set_right_value value)
             bfree((char*)list);
             break;
         }
-        case AST_SET_RIGHT_VALUE_INTEGER_LIST_ENUM: {
-            const char* list = integer_enum_list_value_to_string(value.integer_enum_list_value);
-            if(basprintf(&expr, "(%s)", list) < 0) {
-                abort();
-            }
-            bfree((char*)list);
-            break;
-        }
         default: abort();
     }
     return expr;
@@ -374,7 +366,6 @@ static const char* value_type_to_string(enum betree_value_type_e e)
         case BETREE_SEGMENTS: return "segments";
         case BETREE_FREQUENCY_CAPS: return "frequency_caps";
         case BETREE_INTEGER_ENUM: return "integer_enum";
-        case BETREE_INTEGER_LIST_ENUM: return "integer_enum_list";
         default: return "INVALID";
     }
 }
@@ -411,10 +402,6 @@ void print_variable(const struct betree_variable* v)
             break;
         case BETREE_INTEGER_ENUM:
             printf("%ld", v->value.integer_enum_value.integer);
-            break;
-        case BETREE_INTEGER_LIST_ENUM:
-            inner = integer_enum_list_value_to_string(v->value.integer_enum_list_value);
-            printf("%s", inner);
             break;
         case BETREE_SEGMENTS:
             inner = segments_value_to_string(v->value.segments_value);
@@ -521,16 +508,6 @@ void print_attr_domain(const struct attr_domain* domain)
                 printf("%zu]\n", domain->bound.smax);
             }
             break;
-        case BETREE_INTEGER_LIST_ENUM:
-            printf("%s (integer list enum%s) [", domain->attr_var.attr,
-              domain->allow_undefined ? "?" : "");
-            if(domain->bound.smax >= SIZE_MAX - 1) {
-                printf("SIZE_MAX]\n");
-            }
-            else {
-                printf("%zu]\n", domain->bound.smax);
-            }
-            break;
         case BETREE_SEGMENTS:
             printf("%s (segments%s)\n", domain->attr_var.attr,
               domain->allow_undefined ? "?" : "");
@@ -624,15 +601,6 @@ void print_cdir(const struct cdir* cdir)
                 printf("%zu]\n", cdir->bound.smax);
             }
             break;
-        case BETREE_INTEGER_LIST_ENUM:
-            printf("%s (integer list enum) [%zu, ", cdir->attr_var.attr, cdir->bound.smin);
-            if(cdir->bound.smax >= SIZE_MAX - 1) {
-                printf("SIZE_MAX]\n");
-            }
-            else {
-                printf("%zu]\n", cdir->bound.smax);
-            }
-            break;
         case BETREE_SEGMENTS: abort();
         case BETREE_FREQUENCY_CAPS: abort();
         default: abort();
@@ -657,7 +625,6 @@ void print_value_type(enum betree_value_type_e value_type)
         case BETREE_SEGMENTS: printf("BETREE_SEGMENTS\n"); break;
         case BETREE_FREQUENCY_CAPS: printf("BETREE_FREQUENCY_CAPS\n"); break;
         case BETREE_INTEGER_ENUM: printf("BETREE_INTEGER_ENUM\n"); break;
-        case BETREE_INTEGER_LIST_ENUM: printf("BETREE_INTEGER_LIST_ENUM\n"); break;
         default: abort();
     }
 }

--- a/src/value.c
+++ b/src/value.c
@@ -19,18 +19,6 @@ struct betree_integer_list* make_integer_list()
     return value;
 }
 
-struct betree_integer_enum_list* make_integer_enum_list(size_t count)
-{
-    struct betree_integer_enum_list* value = bcalloc(sizeof(*value));
-    if(value == NULL) {
-        fprintf(stderr, "%s bcalloc failed", __func__);
-        abort();
-    }
-    value->count = count;
-    value->integers = bcalloc(count * sizeof(*value->integers));
-    return value;
-}
-
 struct betree_string_list* make_string_list()
 {
     struct betree_string_list* value = bcalloc(sizeof(*value));
@@ -146,27 +134,6 @@ char* string_list_value_to_string(struct betree_string_list* list)
     return string;
 }
 
-char* integer_enum_list_value_to_string(struct betree_integer_enum_list* list)
-{
-    char* string = NULL;
-    for(size_t i = 0; i < list->count; i++) {
-        char* new_string;
-        if(i != 0) {
-            if(basprintf(&new_string, "%s, %ld", string, list->integers[i].integer) < 0) {
-                abort();
-            }
-            bfree(string);
-        }
-        else {
-            if(basprintf(&new_string, "%ld", list->integers[i].integer) < 0) {
-                abort();
-            }
-        }
-        string = new_string;
-    }
-    return string;
-}
-
 void add_segment(struct betree_segment* segment, struct betree_segments* list)
 {
     if(list->size == 0) {
@@ -272,12 +239,6 @@ void free_integer_list(struct betree_integer_list* value)
     bfree(value);
 }
 
-void free_integer_enum_list(struct betree_integer_enum_list* value)
-{
-    bfree(value->integers);
-    bfree(value);
-}
-
 void free_string_list(struct betree_string_list* value)
 {
     for(size_t i = 0; i < value->count; i++) {
@@ -327,9 +288,6 @@ void free_value(struct value value)
             free_integer_list(value.integer_list_value);
             break;
         }
-        case BETREE_INTEGER_LIST_ENUM:
-            free_integer_enum_list(value.integer_enum_list_value);
-            break;
         case BETREE_STRING_LIST: {
             free_string_list(value.string_list_value);
             break;
@@ -479,29 +437,3 @@ void sort_and_remove_duplicate_string_list(struct betree_string_list* list)
     sort_string_list(list);
     remove_duplicates_string_list(list);
 }
-
-void remove_duplicates_integer_enum_list(struct betree_integer_enum_list* list)
-{
-    if (list->count == 0) {
-        return;
-    }
-    size_t r = 0;
-    for (size_t i = 1; i < list->count; i++) {
-        if (list->integers[r].ienum != list->integers[i].ienum) {
-            list->integers[++ r] = list->integers[i]; // copy-in next unique number
-        }
-    }
-    list->count = r + 1;
-}
-
-void sort_integer_enum_list(struct betree_integer_enum_list* list)
-{
-    qsort(list->integers, list->count, sizeof(*list->integers), iecmpfunc);
-}
-
-void sort_and_remove_duplicate_integer_enum_list(struct betree_integer_enum_list* list)
-{
-    sort_integer_enum_list(list);
-    remove_duplicates_integer_enum_list(list);
-}
-

--- a/src/value.h
+++ b/src/value.h
@@ -32,11 +32,6 @@ struct betree_integer_list {
     int64_t* integers;
 };
 
-struct betree_integer_enum_list {
-    size_t count;
-    struct integer_enum_value* integers;
-};
-
 struct betree_string_list {
     size_t count;
     struct string_value* strings;
@@ -89,7 +84,6 @@ struct value {
         struct betree_segments* segments_value;
         struct betree_frequency_caps* frequency_caps_value;
         struct integer_enum_value integer_enum_value;
-        struct betree_integer_enum_list* integer_enum_list_value;
     };
 };
 
@@ -119,13 +113,11 @@ struct betree_integer_list* make_integer_list();
 struct betree_string_list* make_string_list();
 struct betree_segments* make_segments();
 struct betree_frequency_caps* make_frequency_caps();
-struct betree_integer_enum_list* make_integer_enum_list(size_t count);
 
 void add_integer_list_value(int64_t integer, struct betree_integer_list* list);
 char* integer_list_value_to_string(struct betree_integer_list* list);
 void add_string_list_value(struct string_value string, struct betree_string_list* list);
 char* string_list_value_to_string(struct betree_string_list* list);
-char* integer_enum_list_value_to_string(struct betree_integer_enum_list* list);
 void add_segment(struct betree_segment* segment, struct betree_segments* list);
 void add_frequency(struct betree_frequency_cap* frequency, struct betree_frequency_caps* list);
 struct betree_segment* make_segment(int64_t id, int64_t timestamp);
@@ -146,7 +138,6 @@ void free_segment(struct betree_segment* value);
 void free_segments(struct betree_segments* value);
 void free_frequency_cap(struct betree_frequency_cap* value);
 void free_frequency_caps(struct betree_frequency_caps* value);
-void free_integer_enum_list(struct betree_integer_enum_list* value);
 
 void free_value(struct value value);
 
@@ -156,7 +147,4 @@ void sort_and_remove_duplicate_integer_list(struct betree_integer_list* list);
 void remove_duplicates_string_list(struct betree_string_list* list);
 void sort_string_list(struct betree_string_list* list);
 void sort_and_remove_duplicate_string_list(struct betree_string_list* list);
-void remove_duplicates_integer_enum_list(struct betree_integer_enum_list* list);
-void sort_integer_enum_list(struct betree_integer_enum_list* list);
-void sort_and_remove_duplicate_integer_enum_list(struct betree_integer_enum_list* list);
 

--- a/tests/valid_tests.c
+++ b/tests/valid_tests.c
@@ -104,6 +104,18 @@ int test_valid(enum valid_domain_e domain, bool allow_undefined, const char* exp
     return 0;
 }
 
+int test_missing_domain()
+{
+    struct betree* tree = betree_make();
+    const struct betree_sub* sub = NULL;
+    sub = betree_make_sub(tree, 0, 0, NULL, "var = 1");
+    mu_assert(sub == NULL, "");
+    sub = betree_make_sub(tree, 0, 0, NULL, "var = \"1\"");
+    mu_assert(sub == NULL, "");
+    betree_free(tree);
+    return 0;
+}
+
 int test_comparison()
 {
     // For the event, we don't need to test integer values because in the real code, this never happens
@@ -351,6 +363,7 @@ int test_null()
 
 int all_tests()
 {
+    test_missing_domain();
     test_comparison();
     test_equality();
     test_boolean();

--- a/tests/valid_tests.c
+++ b/tests/valid_tests.c
@@ -1,0 +1,364 @@
+
+#include <float.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "alloc.h"
+#include "betree.h"
+#include "debug.h"
+#include "helper.h"
+#include "minunit.h"
+#include "printer.h"
+#include "tree.h"
+#include "utils.h"
+
+// void add_attr_domain_i(struct config* config, const char* attr, bool allow_undefined);
+// void add_attr_domain_f(struct config* config, const char* attr, bool allow_undefined);
+// void add_attr_domain_b(struct config* config, const char* attr, bool allow_undefined);
+// void add_attr_domain_s(struct config* config, const char* attr, bool allow_undefined);
+// void add_attr_domain_il(struct config* config, const char* attr, bool allow_undefined);
+// void add_attr_domain_sl(struct config* config, const char* attr, bool allow_undefined);
+// void add_attr_domain_segments(struct config* config, const char* attr, bool allow_undefined);
+// void add_attr_domain_frequency(struct config* config, const char* attr, bool allow_undefined);
+// void add_attr_domain_ie(struct config* config, const char* attr, bool allow_undefined);
+
+// 1, 1.1, "1", (1, 2), ("1", "2"), true
+
+enum valid_domain_e {
+    VALID_DOMAIN_I,
+    VALID_DOMAIN_F,
+    VALID_DOMAIN_B,
+    VALID_DOMAIN_S,
+    VALID_DOMAIN_IL,
+    VALID_DOMAIN_SL,
+    VALID_DOMAIN_SEGMENTS,
+    VALID_DOMAIN_FREQUENCY,
+    VALID_DOMAIN_IE,
+};
+
+const char* valid_domain_e_name(enum valid_domain_e domain)
+{
+    switch(domain) {
+        case VALID_DOMAIN_I: return "integer";
+        case VALID_DOMAIN_F: return "float";
+        case VALID_DOMAIN_B: return "boolean";
+        case VALID_DOMAIN_S: return "string";
+        case VALID_DOMAIN_IL: return "integer list";
+        case VALID_DOMAIN_SL: return "string list";
+        case VALID_DOMAIN_SEGMENTS: return "segments";
+        case VALID_DOMAIN_FREQUENCY: return "frequency";
+        case VALID_DOMAIN_IE: return "integer enum";
+        default: return "INVALID";
+    }
+}
+
+int test_valid(enum valid_domain_e domain, bool allow_undefined, const char* expr, bool is_valid, const char* event, size_t matches)
+{
+    struct betree* tree = betree_make();
+    switch(domain) {
+        case VALID_DOMAIN_I:
+            add_attr_domain_i(tree->config, "var", allow_undefined);
+            break;
+        case VALID_DOMAIN_F:
+            add_attr_domain_f(tree->config, "var", allow_undefined);
+            break;
+        case VALID_DOMAIN_B:
+            add_attr_domain_b(tree->config, "var", allow_undefined);
+            break;
+        case VALID_DOMAIN_S:
+            add_attr_domain_s(tree->config, "var", allow_undefined);
+            break;
+        case VALID_DOMAIN_IL:
+            add_attr_domain_il(tree->config, "var", allow_undefined);
+            break;
+        case VALID_DOMAIN_SL:
+            add_attr_domain_sl(tree->config, "var", allow_undefined);
+            break;
+        case VALID_DOMAIN_SEGMENTS:
+            add_attr_domain_segments(tree->config, "var", allow_undefined);
+            break;
+        case VALID_DOMAIN_FREQUENCY:
+            add_attr_domain_frequency(tree->config, "var", allow_undefined);
+            break;
+        case VALID_DOMAIN_IE:
+            add_attr_domain_ie(tree->config, "var", allow_undefined);
+            break;
+        default:
+            mu_assert(false, "Invalid valid domain enum");
+    }
+    const struct betree_sub* sub = betree_make_sub(tree, 0, 0, NULL, expr);
+    if(is_valid) {
+        mu_assert(sub != NULL, "");
+        betree_insert_sub(tree, sub);
+        struct report* report = make_report();
+        mu_assert(betree_search(tree, event, report), "");
+        mu_assert(report->matched == matches, "domain: %s, expr: %s, event: %s", valid_domain_e_name(domain), expr, event);
+        free_report(report);
+    }
+    else {
+        mu_assert(sub == NULL, "");
+    }
+    betree_free(tree);
+    return 0;
+}
+
+int test_comparison()
+{
+    // For the event, we don't need to test integer values because in the real code, this never happens
+    // Integer
+    mu_assert(test_valid(VALID_DOMAIN_I, true, "var < 1", true, "{\"var\": 2}", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_I, true, "var < 1", true, "{\"var\": 0}", 1) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_F, true, "var < 1", true, "{\"var\": 2.0}", 0) == 0, ""); // fix_float_with_no_fractions fixes this
+    mu_assert(test_valid(VALID_DOMAIN_F, true, "var < 1", true, "{\"var\": 0.5}", 1) == 0, ""); // fix_float_with_no_fractions fixes this
+    mu_assert(test_valid(VALID_DOMAIN_B, true, "var < 1", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_S, true, "var < 1", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_IL, true, "var < 1", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_SL, true, "var < 1", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_SEGMENTS, true, "var < 1", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_FREQUENCY, true, "var < 1", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_IE, true, "var < 1", false, "", 0) == 0, "");
+    // Float
+    mu_assert(test_valid(VALID_DOMAIN_I, true, "var < 1.2", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_F, true, "var < 1.2", true, "{\"var\": 2.4}", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_F, true, "var < 1.2", true, "{\"var\": 0.9}", 1) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_B, true, "var < 1.2", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_S, true, "var < 1.2", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_IL, true, "var < 1.2", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_SL, true, "var < 1.2", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_SEGMENTS, true, "var < 1.2", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_FREQUENCY, true, "var < 1.2", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_IE, true, "var < 1.2", false, "", 0) == 0, "");
+    return 0;
+}
+
+int test_equality()
+{
+    // For the event, we don't need to test integer values because in the real code, this never happens
+    // Integer and integer enum
+    mu_assert(test_valid(VALID_DOMAIN_I, true, "var = 0", true, "{\"var\": 2}", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_F, true, "var = 0", true, "{\"var\": 2.0}", 0) == 0, ""); // fix_float_with_no_fractions fixes this
+    mu_assert(test_valid(VALID_DOMAIN_B, true, "var = 0", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_S, true, "var = 0", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IL, true, "var = 0", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SL, true, "var = 0", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SEGMENTS, true, "var = 0", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_FREQUENCY, true, "var = 0", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IE, true, "var = 0", true, "{\"var\": 450}", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IE, true, "var = 450", true, "{\"var\": 450}", 1) == 0, ""); 
+    // Float
+    mu_assert(test_valid(VALID_DOMAIN_I, true, "var = 0.0", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_F, true, "var = 0.0", true, "{\"var\": 2.0}", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_F, true, "var = 0.0", true, "{\"var\": 0.0}", 1) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_B, true, "var = 0.0", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_S, true, "var = 0.0", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IL, true, "var = 0.0", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SL, true, "var = 0.0", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SEGMENTS, true, "var = 0.0", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_FREQUENCY, true, "var = 0.0", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IE, true, "var = 0.0", false, "", 0) == 0, ""); 
+    // String
+    mu_assert(test_valid(VALID_DOMAIN_I, true, "var = \"value\"", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_F, true, "var = \"value\"", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_B, true, "var = \"value\"", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_S, true, "var = \"value\"", true, "{\"var\": \"wrong\"}", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_S, true, "var = \"value\"", true, "{\"var\": \"value\"}", 1) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IL, true, "var = \"value\"", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SL, true, "var = \"value\"", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SEGMENTS, true, "var = \"value\"", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_FREQUENCY, true, "var = \"value\"", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IE, true, "var = \"value\"", false, "", 0) == 0, ""); 
+    return 0;
+}
+
+int test_boolean()
+{
+    mu_assert(test_valid(VALID_DOMAIN_I, true, "var", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_F, true, "var", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_B, true, "var", true, "{\"var\": false}", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_B, true, "var", true, "{\"var\": true}", 1) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_S, true, "var", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IL, true, "var", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SL, true, "var", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SEGMENTS, true, "var", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_FREQUENCY, true, "var", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IE, true, "var", false, "", 0) == 0, ""); 
+    return 0;
+}
+
+int test_set()
+{
+    // Left value, integer
+    mu_assert(test_valid(VALID_DOMAIN_I, true, "1 in var", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_F, true, "1 in var", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_B, true, "1 in var", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_S, true, "1 in var", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IL, true, "1 in var", true, "{\"var\": [0,2]}", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IL, true, "1 in var", true, "{\"var\": [0,1,2]}", 1) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SL, true, "1 in var", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SEGMENTS, true, "1 in var", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_FREQUENCY, true, "1 in var", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IE, true, "1 in var", false, "", 0) == 0, ""); 
+    // Left value, string
+    mu_assert(test_valid(VALID_DOMAIN_I, true, "\"value\" in var", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_F, true, "\"value\" in var", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_B, true, "\"value\" in var", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_S, true, "\"value\" in var", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IL, true, "\"value\" in var", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SL, true, "\"value\" in var", true, "{\"var\": [\"wrong\",\"another\"]}", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SL, true, "\"value\" in var", true, "{\"var\": [\"wrong\",\"value\",\"another\"]}", 1) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SEGMENTS, true, "\"value\" in var", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_FREQUENCY, true, "\"value\" in var", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IE, true, "\"value\" in var", false, "", 0) == 0, ""); 
+    // Right value, integer list
+    mu_assert(test_valid(VALID_DOMAIN_I, true, "var in (0, 2)", true, "{\"var\": 1}", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_I, true, "var in (0, 2)", true, "{\"var\": 2}", 1) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_F, true, "var in (0, 2)", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_B, true, "var in (0, 2)", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_S, true, "var in (0, 2)", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IL, true, "var in (0, 2)", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SL, true, "var in (0, 2)", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SEGMENTS, true, "var in (0, 2)", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_FREQUENCY, true, "var in (0, 2)", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IE, true, "var in (0, 2)", false, "", 0) == 0, ""); 
+    // Right value, string list
+    mu_assert(test_valid(VALID_DOMAIN_I, true, "var in (\"value\", \"another\")", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_F, true, "var in (\"value\", \"another\")", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_B, true, "var in (\"value\", \"another\")", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_S, true, "var in (\"value\", \"another\")", true, "{\"var\": \"wrong\"}", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_S, true, "var in (\"value\", \"another\")", true, "{\"var\": \"value\"}", 1) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IL, true, "var in (\"value\", \"another\")", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SL, true, "var in (\"value\", \"another\")", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SEGMENTS, true, "var in (\"value\", \"another\")", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_FREQUENCY, true, "var in (\"value\", \"another\")", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IE, true, "var in (\"value\", \"another\")", false, "", 0) == 0, ""); 
+    return 0;
+}
+
+int test_list()
+{
+    // Integer list
+    mu_assert(test_valid(VALID_DOMAIN_I, true, "var one of (0, 2)", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_F, true, "var one of (0, 2)", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_B, true, "var one of (0, 2)", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_S, true, "var one of (0, 2)", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IL, true, "var one of (0, 2)", true, "{\"var\": [1, 3]}", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IL, true, "var one of (0, 2)", true, "{\"var\": [1, 2]}", 1) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SL, true, "var one of (0, 2)", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SEGMENTS, true, "var one of (0, 2)", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_FREQUENCY, true, "var one of (0, 2)", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IE, true, "var one of (0, 2)", false, "", 0) == 0, ""); 
+    // String list
+    mu_assert(test_valid(VALID_DOMAIN_I, true, "var one of (\"value\", \"nope\")", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_F, true, "var one of (\"value\", \"nope\")", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_B, true, "var one of (\"value\", \"nope\")", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_S, true, "var one of (\"value\", \"nope\")", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IL, true, "var one of (\"value\", \"nope\")", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SL, true, "var one of (\"value\", \"nope\")", true, "{\"var\": [\"wrong\", \"no\"]}", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SL, true, "var one of (\"value\", \"nope\")", true, "{\"var\": [\"wrong\", \"value\"]}", 1) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SEGMENTS, true, "var one of (\"value\", \"nope\")", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_FREQUENCY, true, "var one of (\"value\", \"nope\")", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IE, true, "var one of (\"value\", \"nope\")", false, "", 0) == 0, ""); 
+    return 0;
+}
+
+int test_null()
+{
+    // null
+    mu_assert(test_valid(VALID_DOMAIN_I, true, "var is null", true, "{\"var\": 1}", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_I, true, "var is null", true, "{}", 1) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_I, false, "var is null", false, "", 1) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_F, true, "var is null", true, "{\"var\": 1.0}", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_F, true, "var is null", true, "{}", 1) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_F, false, "var is null", false, "", 1) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_B, true, "var is null", true, "{\"var\": true}", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_B, true, "var is null", true, "{}", 1) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_B, false, "var is null", false, "", 1) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_S, true, "var is null", true, "{\"var\": \"value\"}", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_S, true, "var is null", true, "{}", 1) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_S, false, "var is null", false, "", 1) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_IL, true, "var is null", true, "{\"var\": [1,2]}", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_IL, true, "var is null", true, "{}", 1) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_IL, false, "var is null", false, "", 1) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_SL, true, "var is null", true, "{\"var\": [\"value\", \"another\"]}", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_SL, true, "var is null", true, "{}", 1) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_SL, false, "var is null", false, "", 1) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_IE, true, "var is null", true, "{\"var\": 2}", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_IE, true, "var is null", true, "{}", 1) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_IE, false, "var is null", false, "", 1) == 0, "");
+    // empty
+    mu_assert(test_valid(VALID_DOMAIN_I, true, "var is empty", false, "", 0) == 0, "");
+    mu_assert(test_valid(VALID_DOMAIN_F, true, "var is empty", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_B, true, "var is empty", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_S, true, "var is empty", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IL, true, "var is empty", true, "{\"var\": [1,2]}", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IL, true, "var is empty", true, "{\"var\": []}", 1) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SL, true, "var is empty", true, "{\"var\": [\"value\", \"another\"]}", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SL, true, "var is empty", true, "{\"var\": []}", 1) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_SEGMENTS, true, "var is empty", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_FREQUENCY, true, "var is empty", false, "", 0) == 0, ""); 
+    mu_assert(test_valid(VALID_DOMAIN_IE, true, "var is empty", false, "", 0) == 0, ""); 
+    return 0;
+}
+
+    // mu_assert(test_valid(VALID_DOMAIN_I, true, "var", false, "", 0) == 0, "");
+    // mu_assert(test_valid(VALID_DOMAIN_F, true, "var", false, "", 0) == 0, ""); 
+    // mu_assert(test_valid(VALID_DOMAIN_B, true, "var", false, "", 0) == 0, ""); 
+    // mu_assert(test_valid(VALID_DOMAIN_S, true, "var", false, "", 0) == 0, ""); 
+    // mu_assert(test_valid(VALID_DOMAIN_IL, true, "var", false, "", 0) == 0, ""); 
+    // mu_assert(test_valid(VALID_DOMAIN_SL, true, "var", false, "", 0) == 0, ""); 
+    // mu_assert(test_valid(VALID_DOMAIN_SEGMENTS, true, "var", false, "", 0) == 0, ""); 
+    // mu_assert(test_valid(VALID_DOMAIN_FREQUENCY, true, "var", false, "", 0) == 0, ""); 
+    // mu_assert(test_valid(VALID_DOMAIN_IE, true, "var", false, "", 0) == 0, ""); 
+
+    // {
+    //     struct betree* tree = betree_make();
+    //     add_attr_domain_s(tree->config, "samsung_device_country", true);
+    //     const char* expr = "samsung_device_country one of (\"US\", \"UK\")";
+    //     const struct betree_sub* sub = betree_make_sub(tree, 0, 0, NULL, expr);
+    //     betree_insert_sub(tree, sub);
+    //     const char* event = "{\"samsung_device_country\": \"UK\"}";
+    //     struct report* report = make_report();
+    //     mu_assert(betree_search(tree, event, report), "");
+    //     free_report(report);
+    //     betree_free(tree);
+    // }
+    // {
+    //     struct betree* tree = betree_make();
+    //     add_attr_domain_s(tree->config, "samsung_device_country", true);
+    //     const char* expr = "samsung_device_country none of (\"US\", \"UK\")";
+    //     const struct betree_sub* sub = betree_make_sub(tree, 0, 0, NULL, expr);
+    //     betree_insert_sub(tree, sub);
+    //     const char* event = "{\"samsung_device_country\": \"FI\"}";
+    //     struct report* report = make_report();
+    //     mu_assert(betree_search(tree, event, report), "");
+    //     free_report(report);
+    //     betree_free(tree);
+    // }
+    // {
+    //     struct betree* tree = betree_make();
+    //     add_attr_domain_i(tree->config, "i", true);
+    //     const char* expr = "i = \"US\"";
+    //     const struct betree_sub* sub = betree_make_sub(tree, 0, 0, NULL, expr);
+    //     betree_insert_sub(tree, sub);
+    //     const char* event = "{\"i\": 1}";
+    //     struct report* report = make_report();
+    //     mu_assert(betree_search(tree, event, report), "");
+    //     free_report(report);
+    //     betree_free(tree);
+    // }
+
+int all_tests()
+{
+    test_comparison();
+    test_equality();
+    test_boolean();
+    test_set();
+    test_list();
+    test_null();
+    return 0;
+}
+
+RUN_TESTS()
+


### PR DESCRIPTION
- Validate boolean expression
    - Do not allow variables and values mismatch
    - Do not allow `disallow_undefined` variables with `is null/is not null` expressions
- Remove integer enum list feature
- Make sure fix_float_with_no_fractions to recursively enter `and/or/not` expressions